### PR TITLE
release: 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+
+## [0.2.0] - 2026-03-07
+
+### Features
+
+- Added `HuckleberryAPI.log_potty()` for potty events stored in the shared diaper tracker; potty changes are observed through the existing diaper listener. ([#potty-api](https://github.com/Woyken/py-huckleberry-api/issues/potty-api))
+- Migrate the client to strict Firebase schema models, require an injected `aiohttp` websession, and remove the separate solids interval API path.

--- a/newsfragments/+8b26b3c8.feature.md
+++ b/newsfragments/+8b26b3c8.feature.md
@@ -1,1 +1,0 @@
-Migrate the client to strict Firebase schema models, require an injected `aiohttp` websession, and remove the separate solids interval API path.

--- a/newsfragments/potty-api.feature.md
+++ b/newsfragments/potty-api.feature.md
@@ -1,1 +1,0 @@
-Added `HuckleberryAPI.log_potty()` for potty events stored in the shared diaper tracker; potty changes are observed through the existing diaper listener.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "huckleberry-api"
-version = "0.1.19"
+version = "0.2.0"
 description = "Python API client for Huckleberry baby tracking app using Firebase Firestore"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -683,7 +683,7 @@ wheels = [
 
 [[package]]
 name = "huckleberry-api"
-version = "0.1.19"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- bump huckleberry-api version to 0.2.0
- build the 0.2.0 changelog from Towncrier fragments
- remove the consumed release note fragments

## Validation
- uv run ruff check .
- uv run ty check --python-version 3.11 --ignore unknown-argument
- uv run pytest tests -q