### PR TITLE
Make certain fields optional for nursing and solids

### DIFF
--- a/newsfragments/deleted-last-summary-payloads.bugfix.md
+++ b/newsfragments/deleted-last-summary-payloads.bugfix.md
@@ -1,0 +1,1 @@
+Allow empty Firebase `prefs.last*` summary maps to validate after a child's sleep, feeding, or diaper history has been cleared.

--- a/src/huckleberry_api/firebase_types.py
+++ b/src/huckleberry_api/firebase_types.py
@@ -272,9 +272,9 @@ class FirebaseLastSleepData(StrictModel):
     `start` and `duration` are in seconds; `offset` is timezone offset minutes.
     """
 
-    start: Number
-    duration: Number
-    offset: Number
+    start: Number | None = None
+    duration: Number | None = None
+    offset: Number | None = None
 
 
 class FirebaseSleepPrefs(StrictModel):
@@ -428,12 +428,12 @@ class FirebaseLastBottleData(StrictModel):
     - intervals use `amount`/`units`
     """
 
-    mode: Literal["bottle"]
-    start: Number
-    bottleType: BottleType
-    bottleAmount: Number
-    bottleUnits: VolumeUnits
-    offset: Number
+    mode: Literal["bottle"] | None = None
+    start: Number | None = None
+    bottleType: BottleType | None = None
+    bottleAmount: Number | None = None
+    bottleUnits: VolumeUnits | None = None
+    offset: Number | None = None
 
 
 class SolidsFoodEntry(StrictModel):
@@ -629,9 +629,9 @@ class FirebaseDiaperData(StrictModel):
 class FirebaseLastDiaperData(StrictModel):
     """diaper/{child_uid}.prefs.lastDiaper structure."""
 
-    start: Number
-    mode: DiaperMode
-    offset: Number
+    start: Number | None = None
+    mode: DiaperMode | None = None
+    offset: Number | None = None
 
 
 class FirebaseLastPottyData(StrictModel):

--- a/tests/test_firebase_types.py
+++ b/tests/test_firebase_types.py
@@ -1,0 +1,55 @@
+"""Unit tests for strict Firebase schema models."""
+
+from huckleberry_api.firebase_types import (
+    FirebaseDiaperDocumentData,
+    FirebaseFeedDocumentData,
+    FirebaseSleepDocumentData,
+)
+
+
+def test_feed_document_accepts_empty_last_summary_maps() -> None:
+    """Empty feed summary maps should validate after history is cleared."""
+    model = FirebaseFeedDocumentData.model_validate(
+        {
+            "prefs": {
+                "lastBottle": {},
+                "lastNursing": {},
+                "lastSolid": {},
+            }
+        }
+    )
+
+    assert model.prefs is not None
+    assert model.prefs.lastBottle is not None
+    assert model.prefs.lastBottle.mode is None
+    assert model.prefs.lastBottle.bottleType is None
+    assert model.prefs.lastNursing is not None
+    assert model.prefs.lastNursing.mode is None
+    assert model.prefs.lastNursing.duration is None
+    assert model.prefs.lastSolid is not None
+    assert model.prefs.lastSolid.mode is None
+    assert model.prefs.lastSolid.foods is None
+
+
+def test_sleep_and_diaper_documents_accept_empty_last_summary_maps() -> None:
+    """Empty sleep and diaper summary maps should validate after deletions."""
+    sleep_model = FirebaseSleepDocumentData.model_validate({"prefs": {"lastSleep": {}}})
+    assert sleep_model.prefs is not None
+    assert sleep_model.prefs.lastSleep is not None
+    assert sleep_model.prefs.lastSleep.start is None
+    assert sleep_model.prefs.lastSleep.duration is None
+
+    diaper_model = FirebaseDiaperDocumentData.model_validate(
+        {
+            "prefs": {
+                "lastDiaper": {},
+                "lastPotty": {},
+            }
+        }
+    )
+    assert diaper_model.prefs is not None
+    assert diaper_model.prefs.lastDiaper is not None
+    assert diaper_model.prefs.lastDiaper.mode is None
+    assert diaper_model.prefs.lastDiaper.start is None
+    assert diaper_model.prefs.lastPotty is not None
+    assert diaper_model.prefs.lastPotty.mode is None


### PR DESCRIPTION
Whenever nursing and solids data are missing (i.e. none of these have been entered for a child), the lastNursing and lastSolid fields in FirebaseFeedPrefs are still present but empty.
This, in turn, causes validation errors for all required fields in the FirebaseLastNursingData and FirebaseLastSolidData messages.
This PR makes such fields optional.

Here is an example of the pydantic validation errors:

```
pydantic_core._pydantic_core.ValidationError: 10 validation errors for FirebaseFeedDocumentData
prefs.lastNursing.mode
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
prefs.lastNursing.start
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
prefs.lastNursing.duration
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
prefs.lastNursing.leftDuration
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
prefs.lastNursing.rightDuration
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
prefs.lastNursing.offset
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
prefs.lastSolid.mode
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
prefs.lastSolid.start
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
prefs.lastSolid.foods
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
prefs.lastSolid.offset
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
```