### PR TITLE
Release v0.3.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,4 @@
-# Huckleberry API — Minimal Agent Guide
-
-This file is intentionally minimal.
+# Huckleberry API
 
 ## Source of Truth
 
@@ -13,11 +11,11 @@ This file is intentionally minimal.
 
 1. **Validate values before adding/changing them**
    - For enums, modes, units, state values, keys, or option lists originating from the app/Firebase schema, validate against APK/Firebase evidence first.
-   - Never add guessed values.
+   - Never add guessed values. If key or value cannot ve verified with decompiled sources or live data, it must not be added.
 
 2. **Keep types strict**
    - Prefer explicit strict models and constrained literals.
-   - Avoid loosening to broad `Any`/open dicts/lists unless evidence requires it.
+   - Avoid loosening to broad `Any`/open dicts/lists.
 
 3. **Use `uv` for Python commands**
    - Run tests and Python commands with `uv` (for example: `uv run pytest ...`).
@@ -35,4 +33,3 @@ This file is intentionally minimal.
 When discovering new payload structures or semantics:
 - Update `src/huckleberry_api/firebase_types.py` first.
 - Add/update tests as needed.
-- Keep this file concise.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## [0.3.0] - 2026-03-15
+
+### Features
+
+- Added pump tracking support with strict Firebase pump models, range queries, and real-time pump listeners. Pump entries can now be logged with `log_pump(...)`, total amounts are stored using the live app's split-per-side payload shape. ([#18](https://github.com/Woyken/py-huckleberry-api/issues/18))
+
+### Bugfixes
+
+- Allowed breastfeed intervals to omit `leftDuration` and `rightDuration`, so `list_feed_intervals(...)` can parse Firebase entries that do not store per-side durations. ([#25](https://github.com/Woyken/py-huckleberry-api/issues/25))
+
+
 ## [0.2.3] - 2026-03-12
 
 ### Bugfixes

--- a/newsfragments/18.feature.md
+++ b/newsfragments/18.feature.md
@@ -1,1 +1,0 @@
-Added pump tracking support with strict Firebase pump models, range queries, and real-time pump listeners. Pump entries can now be logged with `log_pump(...)`, total amounts are stored using the live app's split-per-side payload shape.

--- a/newsfragments/25.bugfix.md
+++ b/newsfragments/25.bugfix.md
@@ -1,1 +1,0 @@
-Allowed breastfeed intervals to omit `leftDuration` and `rightDuration`, so `list_feed_intervals(...)` can parse Firebase entries that do not store per-side durations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "huckleberry-api"
-version = "0.2.3"
+version = "0.3.0"
 description = "Python API client for Huckleberry baby tracking app using Firebase Firestore"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "MIT" }

--- a/src/huckleberry_api/api.py
+++ b/src/huckleberry_api/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 import uuid
@@ -92,6 +93,32 @@ _FEED_INTERVAL_ADAPTER = TypeAdapter(FirebaseFeedIntervalData)
 _HEALTH_ENTRY_ADAPTER = TypeAdapter(HealthDataEntry)
 
 
+async def _raise_for_status_with_details(response: aiohttp.ClientResponse, operation: str) -> None:
+    """Raise an aiohttp status error with the raw response payload included."""
+    if response.status < 400:
+        return
+
+    message = f"{operation} failed with HTTP {response.status}"
+    if response.reason:
+        message = f"{message} {response.reason}"
+
+    try:
+        response_payload = await response.json(content_type=None)
+        message = f"{message}: {json.dumps(response_payload, separators=(',', ':'))}"
+    except aiohttp.ContentTypeError, json.JSONDecodeError, UnicodeDecodeError, ValueError:
+        response_body = await response.text()
+        if response_body:
+            message = f"{message}: {response_body}"
+
+    raise aiohttp.ClientResponseError(
+        response.request_info,
+        response.history,
+        status=response.status,
+        message=message,
+        headers=response.headers,
+    )
+
+
 class FirebaseTokenCredentials(Credentials):
     """Custom credentials class for Firebase SDK."""
 
@@ -150,7 +177,7 @@ class HuckleberryAPI:
                 },
                 timeout=aiohttp.ClientTimeout(total=10),
             ) as response:
-                response.raise_for_status()
+                await _raise_for_status_with_details(response, "Authentication")
                 data = await response.json()
             self.id_token = data["idToken"]
             self.refresh_token = data["refreshToken"]
@@ -159,8 +186,7 @@ class HuckleberryAPI:
 
             _LOGGER.info("Successfully authenticated with Huckleberry")
         except aiohttp.ClientResponseError as err:
-            _LOGGER.error("Authentication failed: %s", err)
-            _LOGGER.error("Firebase status error: status=%s message=%s", err.status, err.message)
+            _LOGGER.error("Authentication failed: status=%s message=%s", err.status, err.message)
             raise
         except aiohttp.ClientError as err:
             _LOGGER.error("Authentication request failed: %s", err)
@@ -190,7 +216,7 @@ class HuckleberryAPI:
                 },
                 timeout=aiohttp.ClientTimeout(total=10),
             ) as response:
-                response.raise_for_status()
+                await _raise_for_status_with_details(response, "Token refresh")
                 data = await response.json()
         except aiohttp.ClientError as err:
             _LOGGER.error("Failed to refresh authentication token: %s", err)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,9 +32,9 @@ _AUTH_CACHE_LOCK = asyncio.Lock()
 async def _load_auth_snapshot(api_instance: HuckleberryAPI, cache_key: tuple[str, str, str]) -> AuthSnapshot:
     """Authenticate once per credential set and reuse the resulting tokens across tests."""
     async with _AUTH_CACHE_LOCK:
-        snapshot = _AUTH_CACHE.get(cache_key)
-        if snapshot and snapshot["token_expires_at"] > time.time() + 300:
-            return snapshot
+        cached_snapshot = _AUTH_CACHE.get(cache_key)
+        if cached_snapshot and cached_snapshot["token_expires_at"] > time.time() + 300:
+            return cached_snapshot
 
         await api_instance.authenticate()
         assert api_instance.id_token is not None
@@ -42,14 +42,14 @@ async def _load_auth_snapshot(api_instance: HuckleberryAPI, cache_key: tuple[str
         assert api_instance.user_uid is not None
         assert api_instance.token_expires_at is not None
 
-        snapshot = {
+        new_snapshot: AuthSnapshot = {
             "id_token": api_instance.id_token,
             "refresh_token": api_instance.refresh_token,
             "user_uid": api_instance.user_uid,
             "token_expires_at": api_instance.token_expires_at,
         }
-        _AUTH_CACHE[cache_key] = snapshot
-        return snapshot
+        _AUTH_CACHE[cache_key] = new_snapshot
+        return new_snapshot
 
 
 @pytest_asyncio.fixture
@@ -88,12 +88,13 @@ async def api(websession: aiohttp.ClientSession) -> AsyncIterator[HuckleberryAPI
         and api_instance.user_uid is not None
         and api_instance.token_expires_at is not None
     ):
-        _AUTH_CACHE[cache_key] = {
+        updated_snapshot: AuthSnapshot = {
             "id_token": api_instance.id_token,
             "refresh_token": api_instance.refresh_token,
             "user_uid": api_instance.user_uid,
             "token_expires_at": api_instance.token_expires_at,
         }
+        _AUTH_CACHE[cache_key] = updated_snapshot
 
 
 @pytest_asyncio.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,14 +3,55 @@
 These fixtures are automatically discovered by pytest and available to all test files.
 """
 
+import asyncio
 import os
+import time
 from collections.abc import AsyncIterator
+from typing import TypedDict
 
 import aiohttp
 import pytest
 import pytest_asyncio
 
 from huckleberry_api import HuckleberryAPI
+
+
+class AuthSnapshot(TypedDict):
+    """Cached authenticated session state reused across integration tests."""
+
+    id_token: str
+    refresh_token: str
+    user_uid: str
+    token_expires_at: float
+
+
+_AUTH_CACHE: dict[tuple[str, str, str], AuthSnapshot] = {}
+_AUTH_CACHE_LOCK = asyncio.Lock()
+
+
+async def _load_auth_snapshot(
+    api_instance: HuckleberryAPI, cache_key: tuple[str, str, str]
+) -> AuthSnapshot:
+    """Authenticate once per credential set and reuse the resulting tokens across tests."""
+    async with _AUTH_CACHE_LOCK:
+        snapshot = _AUTH_CACHE.get(cache_key)
+        if snapshot and snapshot["token_expires_at"] > time.time() + 300:
+            return snapshot
+
+        await api_instance.authenticate()
+        assert api_instance.id_token is not None
+        assert api_instance.refresh_token is not None
+        assert api_instance.user_uid is not None
+        assert api_instance.token_expires_at is not None
+
+        snapshot = {
+            "id_token": api_instance.id_token,
+            "refresh_token": api_instance.refresh_token,
+            "user_uid": api_instance.user_uid,
+            "token_expires_at": api_instance.token_expires_at,
+        }
+        _AUTH_CACHE[cache_key] = snapshot
+        return snapshot
 
 
 @pytest_asyncio.fixture
@@ -31,12 +72,30 @@ async def api(websession: aiohttp.ClientSession) -> AsyncIterator[HuckleberryAPI
         pytest.skip("HUCKLEBERRY_EMAIL, HUCKLEBERRY_PASSWORD, and HUCKLEBERRY_TIMEZONE environment variables required")
 
     api_instance = HuckleberryAPI(email=email, password=password, timezone=timezone, websession=websession)
-    await api_instance.authenticate()
+    cache_key = (email, password, timezone)
+    snapshot = await _load_auth_snapshot(api_instance, cache_key)
+    api_instance.id_token = snapshot["id_token"]
+    api_instance.refresh_token = snapshot["refresh_token"]
+    api_instance.user_uid = snapshot["user_uid"]
+    api_instance.token_expires_at = snapshot["token_expires_at"]
 
     yield api_instance
 
     # Cleanup: stop all listeners
     await api_instance.stop_all_listeners()
+
+    if (
+        api_instance.id_token is not None
+        and api_instance.refresh_token is not None
+        and api_instance.user_uid is not None
+        and api_instance.token_expires_at is not None
+    ):
+        _AUTH_CACHE[cache_key] = {
+            "id_token": api_instance.id_token,
+            "refresh_token": api_instance.refresh_token,
+            "user_uid": api_instance.user_uid,
+            "token_expires_at": api_instance.token_expires_at,
+        }
 
 
 @pytest_asyncio.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,9 +29,7 @@ _AUTH_CACHE: dict[tuple[str, str, str], AuthSnapshot] = {}
 _AUTH_CACHE_LOCK = asyncio.Lock()
 
 
-async def _load_auth_snapshot(
-    api_instance: HuckleberryAPI, cache_key: tuple[str, str, str]
-) -> AuthSnapshot:
+async def _load_auth_snapshot(api_instance: HuckleberryAPI, cache_key: tuple[str, str, str]) -> AuthSnapshot:
     """Authenticate once per credential set and reuse the resulting tokens across tests."""
     async with _AUTH_CACHE_LOCK:
         snapshot = _AUTH_CACHE.get(cache_key)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import time
+from types import SimpleNamespace
 
 import aiohttp
 import pytest
@@ -11,6 +12,55 @@ from huckleberry_api import HuckleberryAPI
 
 class TestAuthentication:
     """Test authentication functionality."""
+
+    async def test_authenticate_invalid_credentials_includes_firebase_error_details(
+        self, websession: aiohttp.ClientSession, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test authentication errors include Firebase response details."""
+
+        class FakeResponse:
+            def __init__(self) -> None:
+                self.status = 400
+                self.reason = "Bad Request"
+                self.headers = {}
+                self.request_info = SimpleNamespace(real_url="https://identitytoolkit.googleapis.com/")
+                self.history = ()
+
+            async def __aenter__(self) -> FakeResponse:
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb) -> bool:
+                return False
+
+            async def text(self) -> str:
+                return '{"error":{"message":"INVALID_LOGIN_CREDENTIALS","errors":[{"message":"INVALID_LOGIN_CREDENTIALS"}]}}'
+
+            async def json(self, *args, **kwargs) -> dict[str, object]:
+                return {
+                    "error": {
+                        "message": "INVALID_LOGIN_CREDENTIALS",
+                        "errors": [{"message": "INVALID_LOGIN_CREDENTIALS"}],
+                    }
+                }
+
+        invalid_api = HuckleberryAPI(
+            email="invalid@test.com", password="wrongpassword", timezone="UTC", websession=websession
+        )
+
+        def fake_post(*args, **kwargs) -> FakeResponse:
+            return FakeResponse()
+
+        monkeypatch.setattr(websession, "post", fake_post)
+
+        with pytest.raises(aiohttp.ClientResponseError) as exc_info:
+            await invalid_api.authenticate()
+
+        assert exc_info.value.status == 400
+        assert "Authentication failed with HTTP 400 Bad Request" in exc_info.value.message
+        assert (
+            '{"error":{"message":"INVALID_LOGIN_CREDENTIALS","errors":[{"message":"INVALID_LOGIN_CREDENTIALS"}]}}'
+            in exc_info.value.message
+        )
 
     async def test_authenticate_success(self, api: HuckleberryAPI) -> None:
         """Test successful authentication."""

--- a/uv.lock
+++ b/uv.lock
@@ -311,7 +311,7 @@ wheels = [
 
 [[package]]
 name = "huckleberry-api"
-version = "0.2.3"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- bump package version to 0.3.0
- build changelog with towncrier and consume pending news fragments
- refresh lockfile metadata for the new version

## Included changes
- add pump tracking support with strict Firebase pump models, range queries, and real-time pump listeners
- allow breastfeed intervals without left/right duration fields to parse correctly