### PR TITLE
Add activity logging and listener support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ async def main() -> None:
 
 ### Pumping Tracking
 - `await log_pump(child_uid, start_time=..., total_amount=..., duration=..., units=...)` - Log pumping entry; total entries are stored split evenly across `leftAmount` and `rightAmount`
-- `await list_pump_intervals(child_uid, start_timestamp, end_timestamp)` - List pump history for a range
+- `await list_pump_intervals(child_uid, start_time, end_time)` - List pump history for a range using `datetime` objects
 
 ### Solids Tracking
 - `await list_solids_curated_foods()` - List curated solids food catalog

--- a/newsfragments/12.feature
+++ b/newsfragments/12.feature
@@ -1,1 +1,0 @@
-Added activity logging, interval listing, and realtime listener support.

--- a/newsfragments/12.feature
+++ b/newsfragments/12.feature
@@ -1,0 +1,1 @@
+Added activity logging, interval listing, and realtime listener support.

--- a/newsfragments/12.feature.md
+++ b/newsfragments/12.feature.md
@@ -1,0 +1,2 @@
+Added activity logging, interval listing, and realtime listener support.
+Changed interval range APIs to accept datetime objects instead of Unix timestamp integers.

--- a/src/huckleberry_api/api.py
+++ b/src/huckleberry_api/api.py
@@ -1776,21 +1776,22 @@ class HuckleberryAPI:
     async def list_sleep_intervals(
         self,
         child_uid: str,
-        start_timestamp: int,
-        end_timestamp: int,
+        start_time: datetime,
+        end_time: datetime,
     ) -> list[FirebaseSleepIntervalData]:
         """
         Fetch sleep intervals from Firestore for a date range.
 
         Args:
             child_uid: Child unique identifier
-            start_timestamp: Start of range (Unix timestamp in seconds)
-            end_timestamp: End of range (Unix timestamp in seconds)
+            start_time: Start of range
+            end_time: End of range
 
         Returns:
             List of Firebase-validated sleep interval entries
         """
         events: list[FirebaseSleepIntervalData] = []
+        start_timestamp, end_timestamp = start_time.timestamp(), end_time.timestamp()
         client = await self._get_firestore_client()
         sleep_ref = client.collection("sleep").document(child_uid)
         intervals_ref = sleep_ref.collection("intervals")
@@ -1838,21 +1839,22 @@ class HuckleberryAPI:
     async def list_feed_intervals(
         self,
         child_uid: str,
-        start_timestamp: int,
-        end_timestamp: int,
+        start_time: datetime,
+        end_time: datetime,
     ) -> list[FirebaseFeedIntervalData]:
         """
         Fetch feeding intervals from Firestore for a date range.
 
         Args:
             child_uid: Child unique identifier
-            start_timestamp: Start of range (Unix timestamp in seconds)
-            end_timestamp: End of range (Unix timestamp in seconds)
+            start_time: Start of range
+            end_time: End of range
 
         Returns:
             List of Firebase-validated feed interval entries
         """
         events: list[FirebaseFeedIntervalData] = []
+        start_timestamp, end_timestamp = start_time.timestamp(), end_time.timestamp()
         client = await self._get_firestore_client()
         feed_ref = client.collection("feed").document(child_uid)
         intervals_ref = feed_ref.collection("intervals")
@@ -1908,21 +1910,22 @@ class HuckleberryAPI:
     async def list_diaper_intervals(
         self,
         child_uid: str,
-        start_timestamp: int,
-        end_timestamp: int,
+        start_time: datetime,
+        end_time: datetime,
     ) -> list[FirebaseDiaperData]:
         """
         Fetch diaper intervals from Firestore for a date range.
 
         Args:
             child_uid: Child unique identifier
-            start_timestamp: Start of range (Unix timestamp in seconds)
-            end_timestamp: End of range (Unix timestamp in seconds)
+            start_time: Start of range
+            end_time: End of range
 
         Returns:
             List of Firebase-validated diaper interval entries
         """
         events: list[FirebaseDiaperData] = []
+        start_timestamp, end_timestamp = start_time.timestamp(), end_time.timestamp()
         client = await self._get_firestore_client()
         diaper_ref = client.collection("diaper").document(child_uid)
         intervals_ref = diaper_ref.collection("intervals")
@@ -1970,21 +1973,22 @@ class HuckleberryAPI:
     async def list_health_entries(
         self,
         child_uid: str,
-        start_timestamp: int,
-        end_timestamp: int,
+        start_time: datetime,
+        end_time: datetime,
     ) -> list[HealthDataEntry]:
         """
         Fetch health entries from Firestore for a date range.
 
         Args:
             child_uid: Child unique identifier
-            start_timestamp: Start of range (Unix timestamp in seconds)
-            end_timestamp: End of range (Unix timestamp in seconds)
+            start_time: Start of range
+            end_time: End of range
 
         Returns:
             List of Firebase-validated health entries
         """
         events: list[HealthDataEntry] = []
+        start_timestamp, end_timestamp = start_time.timestamp(), end_time.timestamp()
         client = await self._get_firestore_client()
         health_ref = client.collection("health").document(child_uid)
         # Health uses "data" subcollection, not "intervals"
@@ -2033,21 +2037,22 @@ class HuckleberryAPI:
     async def list_pump_intervals(
         self,
         child_uid: str,
-        start_timestamp: int,
-        end_timestamp: int,
+        start_time: datetime,
+        end_time: datetime,
     ) -> list[FirebasePumpIntervalData]:
         """
         Fetch pump intervals from Firestore for a date range.
 
         Args:
             child_uid: Child unique identifier
-            start_timestamp: Start of range (Unix timestamp in seconds)
-            end_timestamp: End of range (Unix timestamp in seconds)
+            start_time: Start of range
+            end_time: End of range
 
         Returns:
             List of Firebase-validated pump interval entries
         """
         events: list[FirebasePumpIntervalData] = []
+        start_timestamp, end_timestamp = start_time.timestamp(), end_time.timestamp()
         client = await self._get_firestore_client()
         pump_ref = client.collection("pump").document(child_uid)
         intervals_ref = pump_ref.collection("intervals")
@@ -2095,21 +2100,22 @@ class HuckleberryAPI:
     async def list_activity_intervals(
         self,
         child_uid: str,
-        start_timestamp: int,
-        end_timestamp: int,
+        start_time: datetime,
+        end_time: datetime,
     ) -> list[FirebaseActivityIntervalData]:
         """
         Fetch activity intervals from Firestore for a date range.
 
         Args:
             child_uid: Child unique identifier
-            start_timestamp: Start of range (Unix timestamp in seconds)
-            end_timestamp: End of range (Unix timestamp in seconds)
+            start_time: Start of range
+            end_time: End of range
 
         Returns:
             List of Firebase-validated activity interval entries
         """
         events: list[FirebaseActivityIntervalData] = []
+        start_timestamp, end_timestamp = start_time.timestamp(), end_time.timestamp()
         client = await self._get_firestore_client()
         activities_ref = client.collection("activities").document(child_uid)
         intervals_ref = activities_ref.collection("intervals")

--- a/src/huckleberry_api/api.py
+++ b/src/huckleberry_api/api.py
@@ -23,9 +23,13 @@ from pydantic import TypeAdapter, ValidationError
 
 from .const import AUTH_URL, FIREBASE_API_KEY, REFRESH_URL
 from .firebase_types import (
+    ActivityMode,
     BottleType,
     DiaperMode,
     FeedSide,
+    FirebaseActivityDocumentData,
+    FirebaseActivityIntervalData,
+    FirebaseActivityMultiContainer,
     FirebaseBottleFeedIntervalData,
     FirebaseChildDocument,
     FirebaseCuratedFoodDocument,
@@ -41,6 +45,7 @@ from .firebase_types import (
     FirebaseGrowthData,
     FirebaseHealthDocumentData,
     FirebaseHealthMultiContainer,
+    FirebaseLastActivityData,
     FirebaseLastBottleData,
     FirebaseLastDiaperData,
     FirebaseLastNursingData,
@@ -84,6 +89,7 @@ TDocumentData = TypeVar(
     FirebaseFeedDocumentData,
     FirebaseHealthDocumentData,
     FirebaseDiaperDocumentData,
+    FirebaseActivityDocumentData,
     FirebasePumpDocumentData,
 )
 
@@ -91,6 +97,16 @@ _LOGGER = logging.getLogger(__name__)
 
 _FEED_INTERVAL_ADAPTER = TypeAdapter(FirebaseFeedIntervalData)
 _HEALTH_ENTRY_ADAPTER = TypeAdapter(HealthDataEntry)
+_ACTIVITY_LAST_FIELD_BY_MODE: dict[ActivityMode, str] = {
+    "bath": "lastBath",
+    "brushTeeth": "lastBrushTeeth",
+    "indoorPlay": "lastIndoorPlay",
+    "outdoorPlay": "lastOutdoorPlay",
+    "screenTime": "lastScreenTime",
+    "skinToSkin": "lastSkinToSkin",
+    "storyTime": "lastStoryTime",
+    "tummyTime": "lastTummyTime",
+}
 
 
 async def _raise_for_status_with_details(response: aiohttp.ClientResponse, operation: str) -> None:
@@ -260,6 +276,8 @@ class HuckleberryAPI:
                     await self.setup_health_listener(child_uid, callback)
                 elif listener_type == "diaper":
                     await self.setup_diaper_listener(child_uid, callback)
+                elif listener_type == "activities":
+                    await self.setup_activity_listener(child_uid, callback)
                 elif listener_type == "pump":
                     await self.setup_pump_listener(child_uid, callback)
                 _LOGGER.debug("Recreated %s listener for child %s", listener_type, child_uid)
@@ -1181,7 +1199,7 @@ class HuckleberryAPI:
 
     async def _setup_listener(
         self,
-        collection_name: Literal["sleep", "feed", "health", "diaper", "pump"],
+        collection_name: Literal["sleep", "feed", "health", "diaper", "activities", "pump"],
         child_uid: str,
         callback: Callable[[TDocumentData], None],
     ) -> None:
@@ -1220,6 +1238,8 @@ class HuckleberryAPI:
                         validated = FirebaseFeedDocumentData.model_validate(payload)
                     elif collection_name == "health":
                         validated = FirebaseHealthDocumentData.model_validate(payload)
+                    elif collection_name == "activities":
+                        validated = FirebaseActivityDocumentData.model_validate(payload)
                     elif collection_name == "pump":
                         validated = FirebasePumpDocumentData.model_validate(payload)
                     else:
@@ -1254,6 +1274,12 @@ class HuckleberryAPI:
     ) -> None:
         """Set up real-time listener for diaper document changes."""
         await self._setup_listener("diaper", child_uid, callback)
+
+    async def setup_activity_listener(
+        self, child_uid: str, callback: Callable[[FirebaseActivityDocumentData], None]
+    ) -> None:
+        """Set up real-time listener for activities document changes."""
+        await self._setup_listener("activities", child_uid, callback)
 
     async def setup_pump_listener(self, child_uid: str, callback: Callable[[FirebasePumpDocumentData], None]) -> None:
         """Set up real-time listener for pump document changes."""
@@ -1640,6 +1666,80 @@ class HuckleberryAPI:
             should_update_last_pump,
         )
 
+    async def log_activity(
+        self,
+        child_uid: str,
+        *,
+        mode: ActivityMode,
+        start_time: datetime,
+        duration: float | int | None = None,
+        notes: str | None = None,
+    ) -> None:
+        """Log an activity entry.
+
+        Args:
+            child_uid: Child unique identifier.
+            mode: Activity mode.
+            start_time: Activity start in datetime.
+            duration: Optional activity duration in seconds.
+            notes: Optional notes attached to the interval.
+        """
+        if duration is not None and float(duration) < 0:
+            raise ValueError("duration must be non-negative")
+
+        start_timestamp = start_time.timestamp()
+        current_offset = await self._get_timezone_offset_minutes()
+        current_time = time.time()
+        interval_id = f"{int(current_time * 1000)}-{uuid.uuid4().hex[:20]}"
+
+        interval = FirebaseActivityIntervalData(
+            mode=mode,
+            start=start_timestamp,
+            offset=current_offset,
+            duration=float(duration) if duration is not None else None,
+            end_offset=current_offset if duration is not None else None,
+            lastUpdated=current_time,
+            notes=notes,
+        )
+
+        last_activity = FirebaseLastActivityData(
+            start=start_timestamp,
+            offset=current_offset,
+            duration=float(duration) if duration is not None else None,
+            end_offset=current_offset if duration is not None else None,
+        )
+
+        client = await self._get_firestore_client()
+        activities_ref = client.collection("activities").document(child_uid)
+        activities_doc = await activities_ref.get()
+        await activities_ref.collection("intervals").document(interval_id).set(to_firebase_dict(interval))
+
+        activities_model = FirebaseActivityDocumentData.model_validate(activities_doc.to_dict() or {})
+        last_field_name = _ACTIVITY_LAST_FIELD_BY_MODE[mode]
+        existing_last_activity = (
+            getattr(activities_model.prefs, last_field_name, None) if activities_model.prefs else None
+        )
+        existing_start = existing_last_activity.start if existing_last_activity else None
+        should_update_last_activity = True
+        if existing_start is not None and start_timestamp < float(existing_start):
+            should_update_last_activity = False
+
+        if should_update_last_activity:
+            await activities_ref.update(
+                {
+                    f"prefs.{last_field_name}": to_firebase_dict(last_activity),
+                    "prefs.timestamp": {"seconds": current_time},
+                    "prefs.local_timestamp": current_time,
+                }
+            )
+
+        _LOGGER.info(
+            "Activity logged for child %s with mode %s (updated_last=%s)",
+            child_uid,
+            mode,
+            should_update_last_activity,
+        )
+
     async def get_latest_growth(self, child_uid: str) -> FirebaseGrowthData | None:
         """
         Get the latest growth measurements for a child.
@@ -1989,5 +2089,63 @@ class HuckleberryAPI:
 
         except (GoogleAPICallError, ValidationError) as err:
             _LOGGER.error("Error fetching pump intervals: %s", err)
+
+        return events
+
+    async def list_activity_intervals(
+        self,
+        child_uid: str,
+        start_timestamp: int,
+        end_timestamp: int,
+    ) -> list[FirebaseActivityIntervalData]:
+        """
+        Fetch activity intervals from Firestore for a date range.
+
+        Args:
+            child_uid: Child unique identifier
+            start_timestamp: Start of range (Unix timestamp in seconds)
+            end_timestamp: End of range (Unix timestamp in seconds)
+
+        Returns:
+            List of Firebase-validated activity interval entries
+        """
+        events: list[FirebaseActivityIntervalData] = []
+        client = await self._get_firestore_client()
+        activities_ref = client.collection("activities").document(child_uid)
+        intervals_ref = activities_ref.collection("intervals")
+
+        try:
+            regular_docs = (
+                intervals_ref.where(filter=firestore.FieldFilter("start", ">=", start_timestamp))
+                .where(filter=firestore.FieldFilter("start", "<", end_timestamp))
+                .order_by("start")
+                .stream()
+            )
+
+            async for doc in regular_docs:
+                data = doc.to_dict()
+                if not data or data.get("multi"):
+                    continue
+
+                entry = FirebaseActivityIntervalData.model_validate(data)
+                events.append(entry)
+
+            multi_docs = intervals_ref.where(filter=firestore.FieldFilter("multi", "==", True)).stream()
+
+            async for doc in multi_docs:
+                data = doc.to_dict()
+                if not data:
+                    continue
+
+                container = FirebaseActivityMultiContainer.model_validate(data)
+                for entry in container.data.values():
+                    entry_start = entry.start
+                    if not (start_timestamp <= entry_start < end_timestamp):
+                        continue
+
+                    events.append(entry)
+
+        except (GoogleAPICallError, ValidationError) as err:
+            _LOGGER.error("Error fetching activity intervals: %s", err)
 
         return events

--- a/src/huckleberry_api/firebase_types.py
+++ b/src/huckleberry_api/firebase_types.py
@@ -43,7 +43,7 @@ SolidsReaction = Literal["LOVED", "MEH", "HATED", "ALLERGIC"]
 SolidsFoodSource = Literal["custom", "curated"]
 BottleType = Literal["Breast Milk", "Formula", "Tube Feeding", "Cow Milk", "Goat Milk", "Soy Milk", "Other"]
 VolumeUnits = Literal["ml", "oz"]
-MedicationUnits = Literal["ml", "cup", "tsp", "drops"]
+MedicationUnits = Literal["ml", "oz", "tsp", "drops"]
 TemperatureUnits = Literal["C", "F"]
 GenderType = Literal["M", "F", ""]
 WeightUnits = Literal["kg", "lbs.oz"]
@@ -844,10 +844,84 @@ class FirebasePumpMultiContainer(StrictModel):
 # ---------------------------------------------------------------------------
 
 
+class FirebaseLastActivityData(StrictModel):
+    """activities/{child_uid}.prefs.last* structure.
+
+    Live Firebase stores one summary field per activity mode under `prefs`, for
+    example `lastBath` and `lastStoryTime`.
+    """
+
+    start: Number | None = None
+    offset: Number | None = None
+    duration: Number | None = None
+    end_offset: Number | None = None
+
+
+class FirebaseActivityPrefs(StrictModel):
+    """activities/{child_uid}.prefs structure.
+
+    Verified live summary fields: `lastBath`, `lastBrushTeeth`, `lastIndoorPlay`,
+    `lastOutdoorPlay`, `lastScreenTime`, `lastSkinToSkin`, `lastStoryTime`, and
+    `lastTummyTime`.
+    """
+
+    lastBath: FirebaseLastActivityData | None = None
+    lastBrushTeeth: FirebaseLastActivityData | None = None
+    lastIndoorPlay: FirebaseLastActivityData | None = None
+    lastOutdoorPlay: FirebaseLastActivityData | None = None
+    lastScreenTime: FirebaseLastActivityData | None = None
+    lastSkinToSkin: FirebaseLastActivityData | None = None
+    lastStoryTime: FirebaseLastActivityData | None = None
+    lastTummyTime: FirebaseLastActivityData | None = None
+    timestamp: FirebaseTimestamp | None = None
+    local_timestamp: Number | None = None
+
+
+class FirebaseActivityTimerEntryData(StrictModel):
+    """Per-mode timer entry from activities/{child_uid}.timer.<mode>."""
+
+    active: bool
+    paused: bool | None = None
+    timestamp: FirebaseTimestamp | None = None
+    local_timestamp: Number | None = None
+    startTime: Number | None = Field(
+        default=None,
+        description="Observed activity timer field in milliseconds since epoch.",
+    )
+    endTime: Number | None = Field(
+        default=None,
+        description="Observed on live bath timer payloads in milliseconds since epoch.",
+    )
+    duration: Number | None = None
+    notes: str | None = None
+    uuid: str
+
+
+class FirebaseActivityTimerData(StrictModel):
+    """activities/{child_uid}.timer structure keyed by activity mode."""
+
+    bath: FirebaseActivityTimerEntryData | None = None
+    brushTeeth: FirebaseActivityTimerEntryData | None = None
+    indoorPlay: FirebaseActivityTimerEntryData | None = None
+    outdoorPlay: FirebaseActivityTimerEntryData | None = None
+    screenTime: FirebaseActivityTimerEntryData | None = None
+    skinToSkin: FirebaseActivityTimerEntryData | None = None
+    storyTime: FirebaseActivityTimerEntryData | None = None
+    tummyTime: FirebaseActivityTimerEntryData | None = None
+
+
+class FirebaseActivityDocumentData(StrictModel):
+    """activities/{child_uid} root document."""
+
+    timer: FirebaseActivityTimerData | None = None
+    prefs: FirebaseActivityPrefs | None = None
+
+
 class FirebaseActivityIntervalData(StrictModel):
     """activities/{child_uid}/intervals row.
 
     Activities tracker follows the common `intervals` subcollection convention.
+    Live payloads can also include free-form `notes`.
     """
 
     mode: ActivityMode
@@ -856,6 +930,7 @@ class FirebaseActivityIntervalData(StrictModel):
     duration: Number | None = None
     end_offset: Number | None = None
     lastUpdated: Number | None = None
+    notes: str | None = None
 
 
 class FirebaseActivityMultiContainer(StrictModel):

--- a/src/huckleberry_api/firebase_types.py
+++ b/src/huckleberry_api/firebase_types.py
@@ -847,7 +847,7 @@ class FirebasePumpMultiContainer(StrictModel):
 class FirebaseLastActivityData(StrictModel):
     """activities/{child_uid}.prefs.last* structure.
 
-    Live Firebase stores one summary field per activity mode under `prefs`, for
+    One summary field per activity mode under `prefs`, for
     example `lastBath` and `lastStoryTime`.
     """
 
@@ -858,12 +858,7 @@ class FirebaseLastActivityData(StrictModel):
 
 
 class FirebaseActivityPrefs(StrictModel):
-    """activities/{child_uid}.prefs structure.
-
-    Verified live summary fields: `lastBath`, `lastBrushTeeth`, `lastIndoorPlay`,
-    `lastOutdoorPlay`, `lastScreenTime`, `lastSkinToSkin`, `lastStoryTime`, and
-    `lastTummyTime`.
-    """
+    """activities/{child_uid}.prefs structure."""
 
     lastBath: FirebaseLastActivityData | None = None
     lastBrushTeeth: FirebaseLastActivityData | None = None
@@ -921,7 +916,6 @@ class FirebaseActivityIntervalData(StrictModel):
     """activities/{child_uid}/intervals row.
 
     Activities tracker follows the common `intervals` subcollection convention.
-    Live payloads can also include free-form `notes`.
     """
 
     mode: ActivityMode

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -141,7 +141,11 @@ class TestActivity:
         )
         await asyncio.sleep(1)
 
-        intervals = await api.list_activity_intervals(child_uid, int(created_after), int(time.time() + 3600))
+        intervals = await api.list_activity_intervals(
+            child_uid,
+            datetime.fromtimestamp(created_after, tz=timezone.utc),
+            datetime.fromtimestamp(time.time() + 3600, tz=timezone.utc),
+        )
         created_intervals = [
             interval
             for interval in intervals

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,0 +1,188 @@
+"""Activity tests for Huckleberry API."""
+
+import asyncio
+import time
+from datetime import datetime, timedelta, timezone
+
+from google.cloud import firestore
+
+from huckleberry_api import HuckleberryAPI
+from huckleberry_api.firebase_types import FirebaseActivityDocumentData, FirebaseActivityIntervalData
+
+_LAST_FIELD_BY_MODE = {
+    "bath": "lastBath",
+    "brushTeeth": "lastBrushTeeth",
+    "indoorPlay": "lastIndoorPlay",
+    "outdoorPlay": "lastOutdoorPlay",
+    "screenTime": "lastScreenTime",
+    "skinToSkin": "lastSkinToSkin",
+    "storyTime": "lastStoryTime",
+    "tummyTime": "lastTummyTime",
+}
+
+
+class TestActivity:
+    """Test activity functionality."""
+
+    async def _get_latest_activity_summary(self, api: HuckleberryAPI, child_uid: str, mode: str):
+        """Read the latest per-mode activity summary directly from the root document."""
+        db = await api._get_firestore_client()
+        activity_doc = await db.collection("activities").document(child_uid).get()
+        if not activity_doc.exists:
+            return None
+
+        activity_data = activity_doc.to_dict() or {}
+        activity_model = FirebaseActivityDocumentData.model_validate(activity_data)
+        if activity_model.prefs is None:
+            return None
+
+        return getattr(activity_model.prefs, _LAST_FIELD_BY_MODE[mode], None)
+
+    async def _next_start_time(self, api: HuckleberryAPI, child_uid: str, mode: str) -> datetime:
+        """Choose a start time that will become the latest summary for the selected mode."""
+        minimum_start = time.time()
+        latest_activity = await self._get_latest_activity_summary(api, child_uid, mode)
+        if latest_activity is not None and latest_activity.start is not None:
+            minimum_start = max(minimum_start, float(latest_activity.start) + 60.0)
+        return datetime.fromtimestamp(minimum_start, tz=timezone.utc)
+
+    async def _find_recent_activity_interval(
+        self,
+        api: HuckleberryAPI,
+        child_uid: str,
+        *,
+        created_after: float,
+        mode: str,
+        duration: float | None = None,
+        notes: str | None = None,
+    ) -> dict[str, object]:
+        """Find the activity interval written by the current test."""
+        db = await api._get_firestore_client()
+        intervals_ref = db.collection("activities").document(child_uid).collection("intervals")
+
+        for _ in range(10):
+            recent_intervals = intervals_ref.order_by("start", direction=firestore.Query.DESCENDING).limit(10)
+            intervals_list = list(await recent_intervals.get())
+
+            for interval_doc in intervals_list:
+                interval_data = interval_doc.to_dict()
+                if not interval_data:
+                    continue
+
+                start_value = interval_data.get("start")
+                if not isinstance(start_value, (int, float)) or float(start_value) < created_after:
+                    continue
+
+                if interval_data.get("mode") != mode:
+                    continue
+
+                if duration is not None and interval_data.get("duration") != duration:
+                    continue
+
+                if notes is not None and interval_data.get("notes") != notes:
+                    continue
+
+                return interval_data
+
+            await asyncio.sleep(0.5)
+
+        raise AssertionError("No matching recent activity interval found")
+
+    async def test_log_activity_updates_history_and_latest_summary(self, api: HuckleberryAPI, child_uid: str) -> None:
+        """Test logging an activity interval and updating the matching latest summary."""
+        created_after = time.time()
+        await api.log_activity(
+            child_uid,
+            mode="bath",
+            start_time=await self._next_start_time(api, child_uid, "bath"),
+            duration=900,
+            notes="integration activity test",
+        )
+        await asyncio.sleep(1)
+
+        interval = await self._find_recent_activity_interval(
+            api,
+            child_uid,
+            created_after=created_after,
+            mode="bath",
+            duration=900.0,
+            notes="integration activity test",
+        )
+        assert interval["mode"] == "bath"
+        assert interval["duration"] == 900.0
+        assert interval["notes"] == "integration activity test"
+
+        latest = await self._get_latest_activity_summary(api, child_uid, "bath")
+        assert latest is not None
+        assert latest.duration == 900.0
+        assert latest.end_offset is not None
+
+    async def test_list_activity_intervals(self, api: HuckleberryAPI, child_uid: str) -> None:
+        """Test listing activity intervals within a date range."""
+        created_after = time.time()
+        now = datetime.now(timezone.utc)
+        first_note = f"activity-list-{int(created_after)}-1"
+        second_note = f"activity-list-{int(created_after)}-2"
+
+        await api.log_activity(
+            child_uid,
+            mode="storyTime",
+            start_time=now,
+            duration=300,
+            notes=first_note,
+        )
+        await asyncio.sleep(0.5)
+        await api.log_activity(
+            child_uid,
+            mode="brushTeeth",
+            start_time=now + timedelta(minutes=2),
+            duration=180,
+            notes=second_note,
+        )
+        await asyncio.sleep(1)
+
+        intervals = await api.list_activity_intervals(child_uid, int(created_after), int(time.time() + 3600))
+        created_intervals = [
+            interval
+            for interval in intervals
+            if float(interval.start) >= created_after and interval.notes in {first_note, second_note}
+        ]
+
+        assert len(created_intervals) >= 2
+        assert all(isinstance(interval, FirebaseActivityIntervalData) for interval in created_intervals)
+
+    async def test_log_older_activity_does_not_replace_latest_summary(
+        self, api: HuckleberryAPI, child_uid: str
+    ) -> None:
+        """Test that backfilled activity entries do not replace the latest per-mode summary."""
+        recent_start = await self._next_start_time(api, child_uid, "storyTime")
+        older_start = recent_start - timedelta(hours=3)
+
+        await api.log_activity(
+            child_uid,
+            mode="storyTime",
+            start_time=recent_start,
+            duration=420,
+            notes="recent activity entry",
+        )
+        await asyncio.sleep(1)
+
+        latest_after_recent = await self._get_latest_activity_summary(api, child_uid, "storyTime")
+        assert latest_after_recent is not None
+        assert latest_after_recent.start is not None
+        assert abs(float(latest_after_recent.start) - recent_start.timestamp()) < 2.0
+
+        await api.log_activity(
+            child_uid,
+            mode="storyTime",
+            start_time=older_start,
+            duration=120,
+            notes="older activity entry",
+        )
+        await asyncio.sleep(1)
+
+        latest_after_older = await self._get_latest_activity_summary(api, child_uid, "storyTime")
+        assert latest_after_older is not None
+        assert latest_after_older.start is not None
+        assert abs(float(latest_after_older.start) - recent_start.timestamp()) < 2.0
+        assert latest_after_older.duration == 420.0

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 
 from huckleberry_api import HuckleberryAPI
 from huckleberry_api.firebase_types import (
+    FirebaseActivityIntervalData,
     FirebaseBottleFeedIntervalData,
     FirebaseBreastFeedIntervalData,
     FirebaseGrowthData,
@@ -140,6 +141,40 @@ class TestCalendarIntervals:
             assert isinstance(interval.start, (int, float))
             assert interval.entryMode in ("leftright", "total")
             assert interval.units in ("ml", "oz")
+
+    async def test_list_activity_intervals(self, api: HuckleberryAPI, child_uid: str) -> None:
+        """Test fetching activity intervals for a date range."""
+        await api.log_activity(
+            child_uid,
+            mode="storyTime",
+            start_time=datetime.now(timezone.utc),
+            duration=600,
+            notes="calendar activity test",
+        )
+        await asyncio.sleep(1)
+
+        now = datetime.now(timezone.utc)
+        start_ts = int(now.timestamp()) - 3600
+        end_ts = int(now.timestamp()) + 60
+
+        intervals = await api.list_activity_intervals(child_uid, start_ts, end_ts)
+
+        assert isinstance(intervals, list)
+        assert len(intervals) >= 1
+
+        for interval in intervals:
+            assert isinstance(interval, FirebaseActivityIntervalData)
+            assert isinstance(interval.start, (int, float))
+            assert interval.mode in (
+                "bath",
+                "tummyTime",
+                "storyTime",
+                "screenTime",
+                "skinToSkin",
+                "outdoorPlay",
+                "indoorPlay",
+                "brushTeeth",
+            )
 
     async def test_date_range_filtering(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test that date range filtering works correctly."""

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,7 +1,7 @@
 """Calendar/interval fetching tests for Huckleberry API."""
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from huckleberry_api import HuckleberryAPI
 from huckleberry_api.firebase_types import (
@@ -28,10 +28,10 @@ class TestCalendarIntervals:
 
         # Query for intervals in the last hour
         now = datetime.now(timezone.utc)
-        start_ts = int(now.timestamp()) - 3600  # 1 hour ago
-        end_ts = int(now.timestamp()) + 60  # 1 minute in future
+        start_time = now.replace(microsecond=0) - timedelta(hours=1)
+        end_time = now.replace(microsecond=0) + timedelta(minutes=1)
 
-        intervals = await api.list_sleep_intervals(child_uid, start_ts, end_ts)
+        intervals = await api.list_sleep_intervals(child_uid, start_time, end_time)
 
         assert isinstance(intervals, list)
         # Should have at least the interval we just created
@@ -52,10 +52,10 @@ class TestCalendarIntervals:
 
         # Query for intervals in the last hour
         now = datetime.now(timezone.utc)
-        start_ts = int(now.timestamp()) - 3600
-        end_ts = int(now.timestamp()) + 60
+        start_time = now.replace(microsecond=0) - timedelta(hours=1)
+        end_time = now.replace(microsecond=0) + timedelta(minutes=1)
 
-        intervals = await api.list_feed_intervals(child_uid, start_ts, end_ts)
+        intervals = await api.list_feed_intervals(child_uid, start_time, end_time)
 
         assert isinstance(intervals, list)
         assert len(intervals) >= 1
@@ -79,10 +79,10 @@ class TestCalendarIntervals:
 
         # Query for intervals in the last hour
         now = datetime.now(timezone.utc)
-        start_ts = int(now.timestamp()) - 3600
-        end_ts = int(now.timestamp()) + 60
+        start_time = now.replace(microsecond=0) - timedelta(hours=1)
+        end_time = now.replace(microsecond=0) + timedelta(minutes=1)
 
-        intervals = await api.list_diaper_intervals(child_uid, start_ts, end_ts)
+        intervals = await api.list_diaper_intervals(child_uid, start_time, end_time)
 
         assert isinstance(intervals, list)
         assert len(intervals) >= 1
@@ -100,10 +100,10 @@ class TestCalendarIntervals:
 
         # Query for entries in the last hour
         now = datetime.now(timezone.utc)
-        start_ts = int(now.timestamp()) - 3600
-        end_ts = int(now.timestamp()) + 60
+        start_time = now.replace(microsecond=0) - timedelta(hours=1)
+        end_time = now.replace(microsecond=0) + timedelta(minutes=1)
 
-        entries = await api.list_health_entries(child_uid, start_ts, end_ts)
+        entries = await api.list_health_entries(child_uid, start_time, end_time)
 
         assert isinstance(entries, list)
         assert len(entries) >= 1
@@ -128,10 +128,10 @@ class TestCalendarIntervals:
         await asyncio.sleep(1)
 
         now = datetime.now(timezone.utc)
-        start_ts = int(now.timestamp()) - 3600
-        end_ts = int(now.timestamp()) + 60
+        start_time = now.replace(microsecond=0) - timedelta(hours=1)
+        end_time = now.replace(microsecond=0) + timedelta(minutes=1)
 
-        intervals = await api.list_pump_intervals(child_uid, start_ts, end_ts)
+        intervals = await api.list_pump_intervals(child_uid, start_time, end_time)
 
         assert isinstance(intervals, list)
         assert len(intervals) >= 1
@@ -154,10 +154,10 @@ class TestCalendarIntervals:
         await asyncio.sleep(1)
 
         now = datetime.now(timezone.utc)
-        start_ts = int(now.timestamp()) - 3600
-        end_ts = int(now.timestamp()) + 60
+        start_time = now.replace(microsecond=0) - timedelta(hours=1)
+        end_time = now.replace(microsecond=0) + timedelta(minutes=1)
 
-        intervals = await api.list_activity_intervals(child_uid, start_ts, end_ts)
+        intervals = await api.list_activity_intervals(child_uid, start_time, end_time)
 
         assert isinstance(intervals, list)
         assert len(intervals) >= 1
@@ -179,8 +179,8 @@ class TestCalendarIntervals:
     async def test_date_range_filtering(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test that date range filtering works correctly."""
         # Query for a range far in the past (should return empty or fewer results)
-        old_start = 0  # Unix epoch
-        old_end = 1000000  # Jan 12, 1970
+        old_start = datetime.fromtimestamp(0, tz=timezone.utc)
+        old_end = datetime.fromtimestamp(1000000, tz=timezone.utc)
 
         intervals = await api.list_sleep_intervals(child_uid, old_start, old_end)
 
@@ -190,11 +190,11 @@ class TestCalendarIntervals:
 
     async def test_empty_date_range(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test querying with an empty date range."""
-        now = int(datetime.now(timezone.utc).timestamp())
+        now = datetime.now(timezone.utc).replace(microsecond=0)
 
         # Start equals end - empty range
         intervals = await api.list_sleep_intervals(child_uid, now, now)
 
         assert isinstance(intervals, list)
-        # Should return empty since start < end_timestamp won't match when they're equal
+        # Should return empty since the half-open range is empty when start and end are equal
         assert len(intervals) == 0

--- a/tests/test_firebase_types.py
+++ b/tests/test_firebase_types.py
@@ -1,15 +1,23 @@
 """Unit tests for strict Firebase schema models."""
 
 from huckleberry_api.firebase_types import (
-    FirebaseGrowthData,
+    FirebaseActivityDocumentData,
+    FirebaseActivityIntervalData,
+    FirebaseActivityMultiContainer,
+    FirebaseActivityPrefs,
+    FirebaseActivityTimerData,
+    FirebaseActivityTimerEntryData,
     FirebaseDiaperDocumentData,
     FirebaseFeedDocumentData,
-    FirebaseSleepDocumentData,
+    FirebaseGrowthData,
+    FirebaseLastActivityData,
+    FirebaseLastPumpData,
+    FirebaseMedicationData,
     FirebasePumpDocumentData,
     FirebasePumpIntervalData,
-    FirebasePumpPrefs,
     FirebasePumpMultiContainer,
-    FirebaseLastPumpData,
+    FirebasePumpPrefs,
+    FirebaseSleepDocumentData,
 )
 
 
@@ -108,6 +116,25 @@ def test_growth_model_accepts_sparse_live_app_data_rows() -> None:
     assert model.isNight is None
     assert model.weightUnits == "kg"
     assert model.heightUnits == "cm"
+
+
+def test_medication_model_accepts_live_app_ounce_units() -> None:
+    """Medication schema should accept the live app's oz unit option."""
+    model = FirebaseMedicationData.model_validate(
+        {
+            "type": "health",
+            "mode": "medication",
+            "start": 1773641000.0,
+            "lastUpdated": 1773641001.0,
+            "offset": 0.0,
+            "medication_id": "abc123",
+            "medication_name": "Vitamin D",
+            "amount": 2.0,
+            "units": "oz",
+        }
+    )
+
+    assert model.units == "oz"
 
 
 def test_pump_interval_model() -> None:
@@ -278,3 +305,149 @@ def test_pump_multi_container_model() -> None:
     assert "interval2" in model.data
     assert model.data["interval2"].leftAmount == 1.55
     assert model.data["interval2"].rightAmount == 1.55
+
+
+def test_activity_interval_model_with_notes() -> None:
+    """Activity interval schema should accept verified live notes payloads."""
+    model = FirebaseActivityIntervalData.model_validate(
+        {
+            "mode": "bath",
+            "start": 1773638859.763,
+            "offset": -120.0,
+            "duration": 1020.0,
+            "end_offset": -120.0,
+            "lastUpdated": 1773638865.955,
+            "notes": "j",
+        }
+    )
+
+    assert model.mode == "bath"
+    assert model.duration == 1020.0
+    assert model.notes == "j"
+
+
+def test_last_activity_data_model() -> None:
+    """Activity prefs summary schema should match verified live payloads."""
+    model = FirebaseLastActivityData.model_validate(
+        {
+            "start": 1773638810.595,
+            "offset": -120.0,
+            "duration": 1200.0,
+            "end_offset": -120.0,
+        }
+    )
+
+    assert model.start == 1773638810.595
+    assert model.offset == -120.0
+    assert model.duration == 1200.0
+    assert model.end_offset == -120.0
+
+
+def test_activity_timer_entry_model() -> None:
+    """Per-mode activity timer schema should accept verified live timer payloads."""
+    model = FirebaseActivityTimerEntryData.model_validate(
+        {
+            "active": True,
+            "paused": False,
+            "timestamp": {"seconds": 1773638888.092},
+            "local_timestamp": 1773638888.092,
+            "startTime": 1773638888090.0,
+            "endTime": 1772998750620.0,
+            "duration": 0.0,
+            "notes": "",
+            "uuid": "dca86f2ba764cf06",
+        }
+    )
+
+    assert model.active is True
+    assert model.endTime == 1772998750620.0
+    assert model.uuid == "dca86f2ba764cf06"
+
+
+def test_activity_prefs_and_document_model() -> None:
+    """Activity root document schema should validate verified prefs and timer maps."""
+    prefs = FirebaseActivityPrefs.model_validate(
+        {
+            "lastBath": {
+                "start": 1773638859.763,
+                "offset": -120.0,
+                "duration": 1020.0,
+                "end_offset": -120.0,
+            },
+            "lastStoryTime": {
+                "start": 1773638797.005,
+                "offset": -120.0,
+            },
+            "timestamp": {"seconds": 1773638865.953},
+            "local_timestamp": 1773638865.953,
+        }
+    )
+    timer = FirebaseActivityTimerData.model_validate(
+        {
+            "bath": {
+                "active": True,
+                "paused": False,
+                "timestamp": {"seconds": 1773638888.092},
+                "local_timestamp": 1773638888.092,
+                "startTime": 1773638888090.0,
+                "endTime": 1772998750620.0,
+                "duration": 0.0,
+                "notes": "",
+                "uuid": "dca86f2ba764cf06",
+            },
+            "storyTime": {
+                "active": False,
+                "paused": False,
+                "timestamp": {"seconds": 1773638800.647},
+                "local_timestamp": 1773638800.647,
+                "startTime": 1773638800647.0,
+                "duration": 0.0,
+                "notes": "",
+                "uuid": "dca86f2ba764cf06",
+            },
+        }
+    )
+    document = FirebaseActivityDocumentData.model_validate(
+        {
+            "prefs": prefs.model_dump(by_alias=True, exclude_none=True),
+            "timer": timer.model_dump(by_alias=True, exclude_none=True),
+        }
+    )
+
+    assert document.prefs is not None
+    assert document.prefs.lastBath is not None
+    assert document.prefs.lastBath.duration == 1020.0
+    assert document.timer is not None
+    assert document.timer.bath is not None
+    assert document.timer.bath.active is True
+    assert document.timer.storyTime is not None
+    assert document.timer.storyTime.active is False
+
+
+def test_activity_multi_container_model() -> None:
+    """Activity multi-container schema should validate batched interval docs."""
+    model = FirebaseActivityMultiContainer.model_validate(
+        {
+            "multi": True,
+            "hasMoreRoom": False,
+            "data": {
+                "interval1": {
+                    "mode": "bath",
+                    "start": 1773638859.763,
+                    "offset": -120.0,
+                    "duration": 1020.0,
+                    "end_offset": -120.0,
+                },
+                "interval2": {
+                    "mode": "storyTime",
+                    "start": 1773638797.005,
+                    "offset": -120.0,
+                },
+            },
+        }
+    )
+
+    assert model.multi is True
+    assert len(model.data) == 2
+    assert model.data["interval1"].mode == "bath"
+    assert model.data["interval2"].mode == "storyTime"

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from huckleberry_api import HuckleberryAPI
-from huckleberry_api.firebase_types import FirebasePumpDocumentData
+from huckleberry_api.firebase_types import FirebaseActivityDocumentData, FirebasePumpDocumentData
 from huckleberry_api.models import SolidsFoodReference
 
 
@@ -275,3 +275,38 @@ class TestRealtimeListeners:
         assert last_update.prefs.lastPump is not None
         assert last_update.prefs.lastPump.duration == 900.0
         assert last_update.prefs.lastPump.entryMode == "total"
+
+    async def test_activity_listener(self, api: HuckleberryAPI, child_uid: str) -> None:
+        """Test activities real-time listener."""
+        updates: list[Any] = []
+        minimum_start = time.time()
+        db = await api._get_firestore_client()
+        activity_doc = await db.collection("activities").document(child_uid).get()
+        activity_data = activity_doc.to_dict() or {}
+        activity_model = FirebaseActivityDocumentData.model_validate(activity_data)
+        latest_bath = activity_model.prefs.lastBath if activity_model.prefs else None
+        if latest_bath is not None and latest_bath.start is not None:
+            minimum_start = max(minimum_start, float(latest_bath.start) + 60.0)
+
+        def callback(data: Any) -> None:
+            updates.append(data)
+
+        await api.setup_activity_listener(child_uid, callback)
+        await asyncio.sleep(2)
+
+        await api.log_activity(
+            child_uid,
+            mode="bath",
+            start_time=datetime.fromtimestamp(minimum_start, tz=timezone.utc),
+            duration=900,
+            notes="activity listener test",
+        )
+        await asyncio.sleep(2)
+
+        await api.stop_all_listeners()
+
+        assert len(updates) > 0
+        last_update = updates[-1]
+        assert last_update.prefs is not None
+        assert last_update.prefs.lastBath is not None
+        assert last_update.prefs.lastBath.duration == 900.0

--- a/tests/test_live_firebase_models.py
+++ b/tests/test_live_firebase_models.py
@@ -18,8 +18,11 @@ from google.cloud import firestore
 from huckleberry_api import HuckleberryAPI
 from huckleberry_api.api import CURATED_FOODS_BUCKET, CURATED_FOODS_OBJECT
 from huckleberry_api.firebase_types import (
+    FirebaseActivityDocumentData,
     FirebaseActivityIntervalData,
     FirebaseActivityMultiContainer,
+    FirebaseActivityPrefs,
+    FirebaseActivityTimerData,
     FirebaseBottleFeedIntervalData,
     FirebaseChildDocument,
     FirebaseCuratedFoodDocument,
@@ -299,6 +302,19 @@ async def test_live_latest_health_pump_activities_and_foods(api: HuckleberryAPI)
                     FirebasePumpIntervalData.model_validate(entry.model_dump(by_alias=True, exclude_none=True))
             else:
                 FirebasePumpIntervalData.model_validate(payload)
+
+        activities_doc = await db.collection("activities").document(child_uid).get()
+        activities_payload = _doc_to_dict(activities_doc)
+        if activities_payload:
+            FirebaseActivityDocumentData.model_validate(activities_payload)
+
+            activities_prefs_payload = _as_obj_dict(activities_payload.get("prefs"))
+            if activities_prefs_payload:
+                FirebaseActivityPrefs.model_validate(activities_prefs_payload)
+
+            activities_timer_payload = _as_obj_dict(activities_payload.get("timer"))
+            if activities_timer_payload:
+                FirebaseActivityTimerData.model_validate(activities_timer_payload)
 
         activities_ref = db.collection("activities").document(child_uid).collection("intervals")
         async for doc in _iter_latest_by_doc_id(activities_ref, _max_docs()):

--- a/tests/test_pump.py
+++ b/tests/test_pump.py
@@ -242,7 +242,11 @@ class TestPumpFeeding:
         # Get all intervals, allowing for start times nudged forward to remain newer
         # than an existing latest pump summary in live Firebase.
         end_time = time.time() + 3600.0
-        intervals = await api.list_pump_intervals(child_uid, int(created_after), int(end_time))
+        intervals = await api.list_pump_intervals(
+            child_uid,
+            datetime.fromtimestamp(created_after, tz=timezone.utc),
+            datetime.fromtimestamp(end_time, tz=timezone.utc),
+        )
         expected_amounts = {50.0, 60.0, 70.0}
         created_intervals = [
             interval

--- a/tests/test_solids.py
+++ b/tests/test_solids.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import time
+from datetime import datetime, timedelta, timezone
 
 from google.cloud import firestore
 
@@ -131,10 +132,10 @@ class TestSolidsFeeding:
         )
         await asyncio.sleep(2)
 
-        end_ts = int(time.time()) + 60
-        start_ts = end_ts - 300
+        end_time = datetime.fromtimestamp(time.time() + 60, tz=timezone.utc)
+        start_time = end_time - timedelta(minutes=5)
 
-        entries = await api.list_feed_intervals(child_uid, start_ts, end_ts)
+        entries = await api.list_feed_intervals(child_uid, start_time, end_time)
         solids_entries = [entry for entry in entries if isinstance(entry, FirebaseSolidsFeedIntervalData)]
         assert len(solids_entries) > 0
         assert solids_entries[-1].foods is not None
@@ -148,8 +149,8 @@ class TestSolidsFeeding:
         )
         await asyncio.sleep(2)
 
-        end_ts = int(time.time()) + 60
-        start_ts = end_ts - 300
+        end_time = datetime.fromtimestamp(time.time() + 60, tz=timezone.utc)
+        start_time = end_time - timedelta(minutes=5)
 
-        feed_entries = await api.list_feed_intervals(child_uid, start_ts, end_ts)
+        feed_entries = await api.list_feed_intervals(child_uid, start_time, end_time)
         assert any(entry.mode == "solids" for entry in feed_entries)


### PR DESCRIPTION
## Summary
- add activity logging, interval listing, and realtime listener support to the API
- model activities root documents, timers, prefs summaries, and interval notes in the Firebase types
- expand tests for activity flows and accept the verified medication """oz""" unit option

Part of work to have complete API coverage #12
