### PR TITLE
Add explicit timestamps for historical log APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,8 @@ pip install huckleberry-api
 
 ```python
 import asyncio
-from datetime import datetime
-import aiohttp
 from datetime import datetime, timedelta
+import aiohttp
 
 from huckleberry_api import HuckleberryAPI
 
@@ -111,7 +110,6 @@ Set up real-time listeners for instant updates:
 
 ```python
 import aiohttp
-from datetime import datetime, timedelta
 
 def on_sleep_update(data):
     timer = data.get("timer", {})

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pip install huckleberry-api
 import asyncio
 from datetime import datetime
 import aiohttp
+from datetime import datetime, timedelta
 
 from huckleberry_api import HuckleberryAPI
 
@@ -52,28 +53,53 @@ async def main() -> None:
 
         await api.start_sleep(child_uid)
         await api.complete_sleep(child_uid)
+        await api.log_sleep(
+            child_uid,
+            start_time=datetime.now() - timedelta(hours=3),
+            end_time=datetime.now() - timedelta(hours=2),
+        )
 
         await api.start_nursing(child_uid, side="left")
         await api.switch_nursing_side(child_uid)
         await api.complete_nursing(child_uid)
+        await api.log_nursing(
+            child_uid,
+            start_time=datetime.now() - timedelta(hours=4),
+            end_time=datetime.now() - timedelta(hours=3, minutes=30),
+            side="right",
+        )
 
-        await api.log_bottle(child_uid, amount=120.0, bottle_type="Formula", units="ml")
+        await api.log_bottle(
+            child_uid,
+            start_time=datetime.now() - timedelta(hours=1),
+            amount=120.0,
+            bottle_type="Formula",
+            units="ml",
+        )
         await api.log_pump(
-          child_uid,
-          start_time=datetime.now(),
-          total_amount=120.0,
-          duration=900,
-          units="ml",
+            child_uid,
+            start_time=datetime.now(),
+            total_amount=120.0,
+            duration=900,
+            units="ml",
         )
         await api.log_diaper(
             child_uid,
+            start_time=datetime.now() - timedelta(minutes=45),
             mode="both",
             pee_amount="medium",
             poo_amount="medium",
             color="yellow",
             consistency="solid",
         )
-        await api.log_growth(child_uid, weight=5.2, height=52.0, head=35.0, units="metric")
+        await api.log_growth(
+            child_uid,
+            start_time=datetime.now() - timedelta(days=1),
+            weight=5.2,
+            height=52.0,
+            head=35.0,
+            units="metric",
+        )
 
 
 asyncio.run(main())
@@ -85,6 +111,7 @@ Set up real-time listeners for instant updates:
 
 ```python
 import aiohttp
+from datetime import datetime, timedelta
 
 def on_sleep_update(data):
     timer = data.get("timer", {})
@@ -124,6 +151,7 @@ async def main() -> None:
 - `await resume_sleep(child_uid)` - Resume paused session
 - `await cancel_sleep(child_uid)` - Cancel without saving
 - `await complete_sleep(child_uid)` - Complete and save to history
+- `await log_sleep(child_uid, start_time=..., end_time=..., details=None)` - Log a completed sleep interval with explicit timestamps
 
 ### Feeding Tracking
 - `await start_nursing(child_uid, side)` - Start breastfeeding session
@@ -132,7 +160,8 @@ async def main() -> None:
 - `await switch_nursing_side(child_uid)` - Switch left/right
 - `await cancel_nursing(child_uid)` - Cancel without saving
 - `await complete_nursing(child_uid)` - Complete and save to history
-- `await log_bottle(child_uid, amount, bottle_type, units)` - Log bottle feeding
+- `await log_nursing(child_uid, start_time=..., end_time=..., side="left")` - Log a completed breastfeeding interval with explicit timestamps
+- `await log_bottle(child_uid, start_time=..., amount=..., bottle_type=..., units=...)` - Log bottle feeding with an explicit event timestamp
   - `bottle_type`: "Breast Milk", "Formula", "Cow Milk", "Soy Milk", etc.
   - `amount`: Volume fed (e.g., 120.0)
   - `units`: "ml" or "oz"
@@ -145,16 +174,17 @@ async def main() -> None:
 - `await list_solids_curated_foods()` - List curated solids food catalog
 - `await list_solids_custom_foods(child_uid, include_archived=False)` - List custom solids foods
 - `await create_solids_custom_food(child_uid, name, image="")` - Create custom solids food
-- `await log_solids(child_uid, foods, notes="", reaction=None, food_note_image=None)` - Log solids meal
+- `await log_solids(child_uid, start_time=..., foods=..., notes="", reaction=None, food_note_image=None)` - Log solids meal with an explicit event timestamp
 
 ### Diaper Tracking
-- `await log_diaper(child_uid, mode, pee_amount, poo_amount, color, consistency)` - Log diaper change
+- `await log_diaper(child_uid, start_time=..., mode=..., pee_amount=..., poo_amount=..., color=..., consistency=...)` - Log diaper change with an explicit event timestamp
+- `await log_potty(child_uid, start_time=..., mode=..., how_it_happened=..., pee_amount=..., poo_amount=..., color=..., consistency=...)` - Log potty event with an explicit event timestamp
   - `mode`: "pee", "poo", "both", or "dry"
   - `color`: "yellow", "green", "brown", "black", "red"
   - `consistency`: "runny", "soft", "solid", "hard"
 
 ### Growth Tracking
-- `await log_growth(child_uid, weight, height, head, units)` - Log measurements
+- `await log_growth(child_uid, start_time=..., weight=..., height=..., head=..., units=...)` - Log measurements with an explicit event timestamp
   - `units`: "metric" (kg/cm) or "imperial" (lbs/inches)
 - `await get_latest_growth(child_uid)` - Get latest measurements
 

--- a/newsfragments/11.feature.md
+++ b/newsfragments/11.feature.md
@@ -1,0 +1,1 @@
+Added backfilled entry support for sleep, nursing, bottle, solids, diaper, potty, and growth logging, including explicit timestamp APIs for completed historical entries.

--- a/src/huckleberry_api/api.py
+++ b/src/huckleberry_api/api.py
@@ -648,18 +648,19 @@ class HuckleberryAPI:
 
         current_time = time.time()
         duration_sec = int(end_timestamp - start_timestamp)
+        timezone_offset = await self._get_timezone_offset_minutes()
         sleep_interval = FirebaseSleepIntervalData(
             start=int(start_timestamp),
             duration=duration_sec,
-            offset=await self._get_timezone_offset_minutes(),
-            end_offset=await self._get_timezone_offset_minutes(),
+            offset=timezone_offset,
+            end_offset=timezone_offset,
             details=details,
             lastUpdated=current_time,
         )
         last_sleep_data = FirebaseLastSleepData(
             start=int(start_timestamp),
             duration=duration_sec,
-            offset=await self._get_timezone_offset_minutes(),
+            offset=timezone_offset,
         )
 
         client = await self._get_firestore_client()
@@ -1825,9 +1826,7 @@ class HuckleberryAPI:
 
         start_timestamp = start_time.timestamp()
         current_offset = await self._get_timezone_offset_minutes()
-        end_offset = None
-        if duration is not None:
-            end_offset = await self._get_timezone_offset_minutes()
+        end_offset = current_offset if duration is not None else None
 
         current_time = time.time()
         interval_id = f"{int(current_time * 1000)}-{uuid.uuid4().hex[:20]}"
@@ -1905,9 +1904,7 @@ class HuckleberryAPI:
 
         start_timestamp = start_time.timestamp()
         current_offset = await self._get_timezone_offset_minutes()
-        end_offset = None
-        if duration is not None:
-            end_offset = await self._get_timezone_offset_minutes()
+        end_offset = current_offset if duration is not None else None
         current_time = time.time()
         interval_id = f"{int(current_time * 1000)}-{uuid.uuid4().hex[:20]}"
 

--- a/src/huckleberry_api/api.py
+++ b/src/huckleberry_api/api.py
@@ -31,6 +31,7 @@ from .firebase_types import (
     FirebaseActivityIntervalData,
     FirebaseActivityMultiContainer,
     FirebaseBottleFeedIntervalData,
+    FirebaseBreastFeedIntervalData,
     FirebaseChildDocument,
     FirebaseCuratedFoodDocument,
     FirebaseCustomFoodTypeDocument,
@@ -66,6 +67,8 @@ from .firebase_types import (
     FirebaseSleepTimerData,
     FirebaseSolidsFeedIntervalData,
     FirebaseTimestamp,
+    FirebaseTypesAvailableTypes,
+    FirebaseTypesDocument,
     FirebaseUserDocument,
     HealthDataEntry,
     PooColor,
@@ -629,6 +632,62 @@ class HuckleberryAPI:
 
         _LOGGER.info("Sleep completed for child %s (duration %ss)", child_uid, duration_sec)
 
+    async def log_sleep(
+        self,
+        child_uid: str,
+        *,
+        start_time: datetime,
+        end_time: datetime,
+        details: FirebaseSleepDetails | None = None,
+    ) -> None:
+        """Log a completed sleep interval without using the live timer."""
+        start_timestamp = start_time.timestamp()
+        end_timestamp = end_time.timestamp()
+        if end_timestamp < start_timestamp:
+            raise ValueError("end_time must be after start_time")
+
+        current_time = time.time()
+        duration_sec = int(end_timestamp - start_timestamp)
+        sleep_interval = FirebaseSleepIntervalData(
+            start=int(start_timestamp),
+            duration=duration_sec,
+            offset=await self._get_timezone_offset_minutes(),
+            end_offset=await self._get_timezone_offset_minutes(),
+            details=details,
+            lastUpdated=current_time,
+        )
+        last_sleep_data = FirebaseLastSleepData(
+            start=int(start_timestamp),
+            duration=duration_sec,
+            offset=await self._get_timezone_offset_minutes(),
+        )
+
+        client = await self._get_firestore_client()
+        sleep_ref = client.collection("sleep").document(child_uid)
+        sleep_doc = await sleep_ref.get()
+        sleep_model = FirebaseSleepDocumentData.model_validate(sleep_doc.to_dict() or {})
+        existing_last_sleep = sleep_model.prefs.lastSleep if sleep_model.prefs else None
+        existing_last_sleep_start = existing_last_sleep.start if existing_last_sleep else None
+        should_update_last_sleep = existing_last_sleep_start is None or start_timestamp >= float(
+            existing_last_sleep_start
+        )
+
+        await sleep_ref.collection("intervals").document(uuid.uuid4().hex[:16]).set(to_firebase_dict(sleep_interval))
+
+        if should_update_last_sleep:
+            await sleep_ref.set(
+                {
+                    "prefs": {
+                        "lastSleep": to_firebase_dict(last_sleep_data),
+                        "timestamp": {"seconds": current_time},
+                        "local_timestamp": current_time,
+                    }
+                },
+                merge=True,
+            )
+
+        _LOGGER.info("Sleep logged for child %s (updated_last=%s)", child_uid, should_update_last_sleep)
+
     async def start_nursing(self, child_uid: str, side: FeedSide = "left") -> None:
         """Start nursing tracking."""
         _LOGGER.info("Starting nursing for child %s on %s side", child_uid, side)
@@ -908,19 +967,19 @@ class HuckleberryAPI:
         # Create interval document for history (feed/{child_uid}/intervals)
         feed_intervals_ref = feed_ref.collection("intervals").document(interval_id)
 
-        breast_interval = {
-            "mode": "breast",
-            "start": feed_start_time,
-            "lastSide": last_side_value,
-            "lastUpdated": now_time,
-            "leftDuration": left_duration,
-            "rightDuration": right_duration,
-            "offset": await self._get_timezone_offset_minutes(),
-            "end_offset": await self._get_timezone_offset_minutes(),
-        }
+        breast_interval = FirebaseBreastFeedIntervalData(
+            mode="breast",
+            start=feed_start_time,
+            lastSide=last_side_value,
+            lastUpdated=now_time,
+            leftDuration=left_duration,
+            rightDuration=right_duration,
+            offset=await self._get_timezone_offset_minutes(),
+            end_offset=await self._get_timezone_offset_minutes(),
+        )
 
         try:
-            await feed_intervals_ref.set(breast_interval)
+            await feed_intervals_ref.set(to_firebase_dict(breast_interval))
             _LOGGER.info("Created nursing interval entry: %s", interval_id)
         except GoogleAPICallError as err:
             _LOGGER.error("Failed to create nursing interval entry: %s", err)
@@ -961,9 +1020,92 @@ class HuckleberryAPI:
             "Nursing completed (total duration %ss, L:%ss R:%ss)", total_duration, left_duration, right_duration
         )
 
+    async def log_nursing(
+        self,
+        child_uid: str,
+        *,
+        start_time: datetime,
+        end_time: datetime,
+        side: FeedSide = "left",
+        left_duration: float | int | None = None,
+        right_duration: float | int | None = None,
+    ) -> None:
+        """Log a completed nursing interval without using the live timer."""
+        start_timestamp = start_time.timestamp()
+        end_timestamp = end_time.timestamp()
+        if end_timestamp < start_timestamp:
+            raise ValueError("end_time must be after start_time")
+
+        if (left_duration is None) != (right_duration is None):
+            raise ValueError("Provide both left_duration and right_duration together")
+
+        if left_duration is None and right_duration is None:
+            total_duration = float(end_timestamp - start_timestamp)
+            resolved_left_duration = total_duration if side == "left" else 0.0
+            resolved_right_duration = total_duration if side == "right" else 0.0
+        else:
+            resolved_left_duration = float(left_duration or 0.0)
+            resolved_right_duration = float(right_duration or 0.0)
+            if resolved_left_duration < 0 or resolved_right_duration < 0:
+                raise ValueError("left_duration and right_duration must be non-negative")
+            total_duration = resolved_left_duration + resolved_right_duration
+
+        current_time = time.time()
+        interval_id = f"{int(current_time * 1000)}-{uuid.uuid4().hex[:20]}"
+        offset = await self._get_timezone_offset_minutes()
+        end_offset = await self._get_timezone_offset_minutes()
+        breast_interval = FirebaseBreastFeedIntervalData(
+            mode="breast",
+            start=start_timestamp,
+            lastSide=side,
+            lastUpdated=current_time,
+            leftDuration=resolved_left_duration,
+            rightDuration=resolved_right_duration,
+            offset=offset,
+            end_offset=end_offset,
+        )
+        last_nursing_data = FirebaseLastNursingData(
+            mode="breast",
+            start=start_timestamp,
+            duration=total_duration,
+            leftDuration=resolved_left_duration,
+            rightDuration=resolved_right_duration,
+            offset=offset,
+        )
+        last_side_data = FirebaseLastSideData(start=start_timestamp, lastSide=side)
+
+        client = await self._get_firestore_client()
+        feed_ref = client.collection("feed").document(child_uid)
+        feed_doc = await feed_ref.get()
+        feed_model = FirebaseFeedDocumentData.model_validate(feed_doc.to_dict() or {})
+        existing_last_nursing = feed_model.prefs.lastNursing if feed_model.prefs else None
+        existing_last_nursing_start = existing_last_nursing.start if existing_last_nursing else None
+        should_update_last_nursing = existing_last_nursing_start is None or start_timestamp >= float(
+            existing_last_nursing_start
+        )
+
+        await feed_ref.collection("intervals").document(interval_id).set(to_firebase_dict(breast_interval))
+
+        if should_update_last_nursing:
+            await feed_ref.set(
+                {
+                    "prefs": {
+                        "lastNursing": to_firebase_dict(last_nursing_data),
+                        "lastSide": to_firebase_dict(last_side_data),
+                        "timestamp": {"seconds": current_time},
+                        "local_timestamp": current_time,
+                    }
+                },
+                merge=True,
+            )
+
+        _LOGGER.info("Nursing logged for child %s (updated_last=%s)", child_uid, should_update_last_nursing)
+
     async def log_bottle(
         self,
         child_uid: str,
+        *,
+        start_time: datetime,
         amount: float,
         bottle_type: BottleType = "Formula",
         units: VolumeUnits = "ml",
@@ -972,6 +1114,7 @@ class HuckleberryAPI:
 
         Args:
             child_uid: Child unique identifier
+            start_time: Event time
             bottle_type: Type of bottle contents ("Breast Milk", "Formula", "Cow Milk", etc.)
             amount: Amount fed in specified units
             units: Volume units ("ml" or "oz")
@@ -981,19 +1124,28 @@ class HuckleberryAPI:
         client = await self._get_firestore_client()
         feed_ref = client.collection("feed").document(child_uid)
 
-        now_time = time.time()
-        interval_id = f"{int(now_time * 1000)}-{uuid.uuid4().hex[:20]}"
+        start_timestamp = start_time.timestamp()
+        current_time = time.time()
+        interval_id = f"{int(current_time * 1000)}-{uuid.uuid4().hex[:20]}"
+        offset = await self._get_timezone_offset_minutes()
+        feed_doc = await feed_ref.get()
+        feed_model = FirebaseFeedDocumentData.model_validate(feed_doc.to_dict() or {})
+        existing_last_bottle = feed_model.prefs.lastBottle if feed_model.prefs else None
+        existing_last_bottle_start = existing_last_bottle.start if existing_last_bottle else None
+        should_update_last_bottle = existing_last_bottle_start is None or start_timestamp >= float(
+            existing_last_bottle_start
+        )
 
         # Create interval document for bottle feeding
         bottle_entry = FirebaseBottleFeedIntervalData(
             mode="bottle",
-            start=now_time,
-            lastUpdated=now_time,
+            start=start_timestamp,
+            lastUpdated=current_time,
             bottleType=bottle_type,
             amount=amount,
             units=units,
-            offset=await self._get_timezone_offset_minutes(),
-            end_offset=await self._get_timezone_offset_minutes(),
+            offset=offset,
+            end_offset=offset,
         )
 
         # Create interval document
@@ -1009,28 +1161,35 @@ class HuckleberryAPI:
         # Update prefs.lastBottle and document-level bottle preferences
         last_bottle_data = FirebaseLastBottleData(
             mode="bottle",
-            start=now_time,
+            start=start_timestamp,
             bottleType=bottle_type,
             bottleAmount=amount,
             bottleUnits=units,
-            offset=await self._get_timezone_offset_minutes(),
+            offset=offset,
         )
 
-        await feed_ref.set(
-            {
-                "prefs": {
-                    "lastBottle": to_firebase_dict(last_bottle_data),
-                    "bottleType": bottle_type,  # Update defaults
-                    "bottleAmount": amount,
-                    "bottleUnits": units,
-                    "timestamp": {"seconds": now_time},
-                    "local_timestamp": now_time,
-                }
-            },
-            merge=True,
-        )
+        if should_update_last_bottle:
+            await feed_ref.set(
+                {
+                    "prefs": {
+                        "lastBottle": to_firebase_dict(last_bottle_data),
+                        "bottleType": bottle_type,
+                        "bottleAmount": amount,
+                        "bottleUnits": units,
+                        "timestamp": {"seconds": current_time},
+                        "local_timestamp": current_time,
+                    }
+                },
+                merge=True,
+            )
 
-        _LOGGER.info("Bottle feeding logged: %s %s of %s", amount, units, bottle_type)
+        _LOGGER.info(
+            "Bottle feeding logged: %s %s of %s (updated_last=%s)",
+            amount,
+            units,
+            bottle_type,
+            should_update_last_bottle,
+        )
 
     async def list_solids_curated_foods(self) -> list[FirebaseCuratedFoodDocument]:
         """List curated solids foods from Firebase Storage."""
@@ -1109,7 +1268,8 @@ class HuckleberryAPI:
 
         client = await self._get_firestore_client()
         types_ref = client.collection("types").document(child_uid)
-        await types_ref.set({"available_types": {"solids": True}}, merge=True)
+        types_document = FirebaseTypesDocument(available_types=FirebaseTypesAvailableTypes(solids=True))
+        await types_ref.set(to_firebase_dict(types_document), merge=True)
         await types_ref.collection("custom").document(food_id).set(to_firebase_dict(custom_food))
 
         return custom_food
@@ -1117,6 +1277,8 @@ class HuckleberryAPI:
     async def log_solids(
         self,
         child_uid: str,
+        *,
+        start_time: datetime,
         foods: list[SolidsFoodReference],
         notes: str = "",
         reaction: SolidsReaction | None = None,
@@ -1126,6 +1288,7 @@ class HuckleberryAPI:
 
         Args:
             child_uid: Child unique identifier
+            start_time: Event time
             foods: Existing food references with explicit id/source/name/amount
             notes: Optional notes about the meal
             reaction: Optional reaction - "LOVED", "MEH", "HATED", or "ALLERGIC"
@@ -1139,8 +1302,17 @@ class HuckleberryAPI:
         client = await self._get_firestore_client()
         feed_ref = client.collection("feed").document(child_uid)
 
-        now_time = time.time()
-        interval_id = f"{int(now_time * 1000)}-{uuid.uuid4().hex[:20]}"
+        start_timestamp = start_time.timestamp()
+        current_time = time.time()
+        interval_id = f"{int(current_time * 1000)}-{uuid.uuid4().hex[:20]}"
+        offset = await self._get_timezone_offset_minutes()
+        feed_doc = await feed_ref.get()
+        feed_model = FirebaseFeedDocumentData.model_validate(feed_doc.to_dict() or {})
+        existing_last_solid = feed_model.prefs.lastSolid if feed_model.prefs else None
+        existing_last_solid_start = existing_last_solid.start if existing_last_solid else None
+        should_update_last_solid = existing_last_solid_start is None or start_timestamp >= float(
+            existing_last_solid_start
+        )
 
         foods_dict: dict[str, SolidsFoodEntry] = {}
         for food_item in foods:
@@ -1163,9 +1335,9 @@ class HuckleberryAPI:
 
         entry = FirebaseSolidsFeedIntervalData(
             mode="solids",
-            start=now_time,
-            lastUpdated=now_time,
-            offset=await self._get_timezone_offset_minutes(),
+            start=start_timestamp,
+            lastUpdated=current_time,
+            offset=offset,
             foods=foods_dict,
         )
 
@@ -1180,22 +1352,26 @@ class HuckleberryAPI:
 
         last_solid = FirebaseLastSolidData(
             mode="solids",
-            start=now_time,
+            start=start_timestamp,
             foods=foods_dict,
             reactions={reaction: True} if reaction else None,
             notes=notes if notes else None,
-            offset=await self._get_timezone_offset_minutes(),
+            offset=offset,
         )
 
-        await feed_ref.update(
-            {
-                "prefs.lastSolid": to_firebase_dict(last_solid),
-                "prefs.timestamp": {"seconds": now_time},
-                "prefs.local_timestamp": now_time,
-            }
-        )
+        if should_update_last_solid:
+            await feed_ref.set(
+                {
+                    "prefs": {
+                        "lastSolid": to_firebase_dict(last_solid),
+                        "timestamp": {"seconds": current_time},
+                        "local_timestamp": current_time,
+                    }
+                },
+                merge=True,
+            )
 
-        _LOGGER.info("Solids logged with %d references", len(foods_dict))
+        _LOGGER.info("Solids logged with %d references (updated_last=%s)", len(foods_dict), should_update_last_solid)
 
     async def _setup_listener(
         self,
@@ -1308,6 +1484,7 @@ class HuckleberryAPI:
         child_uid: str,
         mode: DiaperMode,
         *,
+        start_time: datetime,
         pref_field: Literal["lastDiaper", "lastPotty"],
         pee_amount: Literal["little", "medium", "big"] | None = None,
         poo_amount: Literal["little", "medium", "big"] | None = None,
@@ -1325,8 +1502,16 @@ class HuckleberryAPI:
         client = await self._get_firestore_client()
         diaper_ref = client.collection("diaper").document(child_uid)
 
+        start_timestamp = start_time.timestamp()
         current_time = time.time()
         current_offset = await self._get_timezone_offset_minutes()
+        diaper_doc = await diaper_ref.get()
+        diaper_model = FirebaseDiaperDocumentData.model_validate(diaper_doc.to_dict() or {})
+        existing_last_event = getattr(diaper_model.prefs, pref_field, None) if diaper_model.prefs else None
+        existing_last_event_start = existing_last_event.start if existing_last_event else None
+        should_update_last_event = existing_last_event_start is None or start_timestamp >= float(
+            existing_last_event_start
+        )
 
         # Create interval ID (timestamp in ms + random suffix)
         interval_timestamp_ms = int(current_time * 1000)
@@ -1334,7 +1519,7 @@ class HuckleberryAPI:
 
         # Build interval data (matching app behavior - minimal fields by default)
         interval_data = FirebaseDiaperData(
-            start=current_time,
+            start=start_timestamp,
             lastUpdated=current_time,
             mode=mode,
             offset=current_offset,
@@ -1377,35 +1562,43 @@ class HuckleberryAPI:
         prefs_entry: FirebaseLastDiaperData | FirebaseLastPottyData
         if pref_field == "lastDiaper":
             prefs_entry = FirebaseLastDiaperData(
-                start=current_time,
+                start=start_timestamp,
                 mode=mode,
                 offset=current_offset,
             )
         else:
             prefs_entry = FirebaseLastPottyData(
-                start=current_time,
+                start=start_timestamp,
                 mode=mode,
                 offset=current_offset,
             )
 
-        try:
-            await diaper_ref.update(
-                {
-                    f"prefs.{pref_field}": to_firebase_dict(prefs_entry),
-                    "prefs.timestamp": {"seconds": current_time},
-                    "prefs.local_timestamp": current_time,
-                }
-            )
-            _LOGGER.info("Updated %s prefs", pref_field)
-        except GoogleAPICallError as err:
-            _LOGGER.error("Failed to update %s prefs: %s", pref_field, err)
-            raise
+        if should_update_last_event:
+            try:
+                await diaper_ref.set(
+                    {
+                        "prefs": {
+                            pref_field: to_firebase_dict(prefs_entry),
+                            "timestamp": {"seconds": current_time},
+                            "local_timestamp": current_time,
+                        }
+                    },
+                    merge=True,
+                )
+                _LOGGER.info("Updated %s prefs", pref_field)
+            except GoogleAPICallError as err:
+                _LOGGER.error("Failed to update %s prefs: %s", pref_field, err)
+                raise
 
-        _LOGGER.info("%s event logged successfully", event_kind.capitalize())
+        _LOGGER.info(
+            "%s event logged successfully (updated_last=%s)", event_kind.capitalize(), should_update_last_event
+        )
 
     async def log_diaper(
         self,
         child_uid: str,
+        *,
+        start_time: datetime,
         mode: DiaperMode,
         pee_amount: Literal["little", "medium", "big"] | None = None,
         poo_amount: Literal["little", "medium", "big"] | None = None,
@@ -1419,6 +1612,7 @@ class HuckleberryAPI:
 
         Args:
             child_uid: Child unique identifier
+            start_time: Event time
             mode: One of 'pee', 'poo', 'both', 'dry'
             pee_amount: Pee amount - 'little', 'medium', 'big', or None (no quantity)
             poo_amount: Poo amount - 'little', 'medium', 'big', or None (no quantity)
@@ -1437,11 +1631,14 @@ class HuckleberryAPI:
             consistency=consistency,
             diaper_rash=diaper_rash,
             notes=notes,
+            start_time=start_time,
         )
 
     async def log_potty(
         self,
         child_uid: str,
+        *,
+        start_time: datetime,
         mode: DiaperMode,
         how_it_happened: PottyResult,
         pee_amount: Literal["little", "medium", "big"] | None = None,
@@ -1454,6 +1651,7 @@ class HuckleberryAPI:
 
         Args:
             child_uid: Child unique identifier
+            start_time: Event time
             mode: One of 'pee', 'poo', 'both', 'dry'
             how_it_happened: One of 'satButDry', 'wentPotty', or 'accident'
             pee_amount: Pee amount - 'little', 'medium', 'big', or None (no quantity)
@@ -1473,11 +1671,14 @@ class HuckleberryAPI:
             notes=notes,
             is_potty=True,
             how_it_happened=how_it_happened,
+            start_time=start_time,
         )
 
     async def log_growth(
         self,
         child_uid: str,
+        *,
+        start_time: datetime,
         weight: float | None = None,
         height: float | None = None,
         head: float | None = None,
@@ -1488,6 +1689,7 @@ class HuckleberryAPI:
 
         Args:
             child_uid: Child unique identifier
+            start_time: Event time
             weight: Weight measurement (kg for metric, lbs for imperial)
             height: Height measurement (cm for metric, inches for imperial)
             head: Head circumference (cm for metric, inches for imperial)
@@ -1501,7 +1703,16 @@ class HuckleberryAPI:
         client = await self._get_firestore_client()
         health_ref = client.collection("health").document(child_uid)
 
+        start_timestamp = start_time.timestamp()
         current_time = time.time()
+        current_offset = await self._get_timezone_offset_minutes()
+        health_doc = await health_ref.get()
+        health_model = FirebaseHealthDocumentData.model_validate(health_doc.to_dict() or {})
+        existing_last_growth = health_model.prefs.lastGrowthEntry if health_model.prefs else None
+        existing_last_growth_start = existing_last_growth.start if existing_last_growth else None
+        should_update_last_growth = existing_last_growth_start is None or start_timestamp >= float(
+            existing_last_growth_start
+        )
 
         # Create interval ID (timestamp in ms + random suffix)
         interval_timestamp_ms = int(current_time * 1000)
@@ -1512,9 +1723,9 @@ class HuckleberryAPI:
             id_=interval_id,
             type="health",
             mode="growth",
-            start=current_time,
+            start=start_timestamp,
             lastUpdated=current_time,
-            offset=await self._get_timezone_offset_minutes(),
+            offset=current_offset,
             isNight=False,
             multientry_key=None,
         )
@@ -1553,18 +1764,20 @@ class HuckleberryAPI:
             # Continue to update prefs even if subcollection write fails
 
         # Update prefs.lastGrowthEntry and timestamps (matches Huckleberry app structure)
-        try:
-            await health_ref.update(
-                {
-                    "prefs.lastGrowthEntry": to_firebase_dict(growth_entry),
-                    "prefs.timestamp": {"seconds": current_time},
-                    "prefs.local_timestamp": current_time,
-                }
-            )
-            _LOGGER.info("Growth data logged successfully")
-        except GoogleAPICallError as err:
-            _LOGGER.error("Failed to log growth data: %s", err)
-            raise
+        if should_update_last_growth:
+            try:
+                await health_ref.update(
+                    {
+                        "prefs.lastGrowthEntry": to_firebase_dict(growth_entry),
+                        "prefs.timestamp": {"seconds": current_time},
+                        "prefs.local_timestamp": current_time,
+                    }
+                )
+            except GoogleAPICallError as err:
+                _LOGGER.error("Failed to log growth data: %s", err)
+                raise
+
+        _LOGGER.info("Growth data logged successfully (updated_last=%s)", should_update_last_growth)
 
     async def log_pump(
         self,
@@ -1612,6 +1825,9 @@ class HuckleberryAPI:
 
         start_timestamp = start_time.timestamp()
         current_offset = await self._get_timezone_offset_minutes()
+        end_offset = None
+        if duration is not None:
+            end_offset = await self._get_timezone_offset_minutes()
 
         current_time = time.time()
         interval_id = f"{int(current_time * 1000)}-{uuid.uuid4().hex[:20]}"
@@ -1623,7 +1839,7 @@ class HuckleberryAPI:
             units=units,
             offset=current_offset,
             duration=float(duration) if duration is not None else None,
-            end_offset=current_offset if duration is not None else None,
+            end_offset=end_offset,
             lastUpdated=current_time,
             notes=notes,
         )
@@ -1689,6 +1905,9 @@ class HuckleberryAPI:
 
         start_timestamp = start_time.timestamp()
         current_offset = await self._get_timezone_offset_minutes()
+        end_offset = None
+        if duration is not None:
+            end_offset = await self._get_timezone_offset_minutes()
         current_time = time.time()
         interval_id = f"{int(current_time * 1000)}-{uuid.uuid4().hex[:20]}"
 
@@ -1697,7 +1916,7 @@ class HuckleberryAPI:
             start=start_timestamp,
             offset=current_offset,
             duration=float(duration) if duration is not None else None,
-            end_offset=current_offset if duration is not None else None,
+            end_offset=end_offset,
             lastUpdated=current_time,
             notes=notes,
         )
@@ -1706,7 +1925,7 @@ class HuckleberryAPI:
             start=start_timestamp,
             offset=current_offset,
             duration=float(duration) if duration is not None else None,
-            end_offset=current_offset if duration is not None else None,
+            end_offset=end_offset,
         )
 
         client = await self._get_firestore_client()

--- a/src/huckleberry_api/api.py
+++ b/src/huckleberry_api/api.py
@@ -643,14 +643,16 @@ class HuckleberryAPI:
         """Log a completed sleep interval without using the live timer."""
         start_timestamp = start_time.timestamp()
         end_timestamp = end_time.timestamp()
-        if end_timestamp < start_timestamp:
+        start_sec = int(start_timestamp)
+        end_sec = int(end_timestamp)
+        if end_sec < start_sec:
             raise ValueError("end_time must be after start_time")
 
         current_time = time.time()
-        duration_sec = int(end_timestamp - start_timestamp)
+        duration_sec = end_sec - start_sec
         timezone_offset = await self._get_timezone_offset_minutes()
         sleep_interval = FirebaseSleepIntervalData(
-            start=int(start_timestamp),
+            start=start_sec,
             duration=duration_sec,
             offset=timezone_offset,
             end_offset=timezone_offset,
@@ -658,7 +660,7 @@ class HuckleberryAPI:
             lastUpdated=current_time,
         )
         last_sleep_data = FirebaseLastSleepData(
-            start=int(start_timestamp),
+            start=start_sec,
             duration=duration_sec,
             offset=timezone_offset,
         )
@@ -669,7 +671,7 @@ class HuckleberryAPI:
         sleep_model = FirebaseSleepDocumentData.model_validate(sleep_doc.to_dict() or {})
         existing_last_sleep = sleep_model.prefs.lastSleep if sleep_model.prefs else None
         existing_last_sleep_start = existing_last_sleep.start if existing_last_sleep else None
-        should_update_last_sleep = existing_last_sleep_start is None or start_timestamp >= float(
+        should_update_last_sleep = existing_last_sleep_start is None or float(start_sec) >= float(
             existing_last_sleep_start
         )
 

--- a/tests/test_bottle_feeding.py
+++ b/tests/test_bottle_feeding.py
@@ -72,7 +72,7 @@ class TestBottleFeeding:
         """Test logging formula bottle feeding."""
         # Log formula bottle
         start_time = await self._next_bottle_start_time(api, child_uid)
-        created_after = time.time()
+        created_after = start_time.timestamp()
         await api.log_bottle(child_uid, start_time=start_time, amount=120.0, bottle_type="Formula", units="ml")
         await asyncio.sleep(2)
 
@@ -109,7 +109,7 @@ class TestBottleFeeding:
         """Test logging breast milk bottle feeding."""
         # Log breast milk bottle
         start_time = await self._next_bottle_start_time(api, child_uid)
-        created_after = time.time()
+        created_after = start_time.timestamp()
         await api.log_bottle(child_uid, start_time=start_time, amount=90.0, bottle_type="Breast Milk", units="ml")
         await asyncio.sleep(2)
 

--- a/tests/test_bottle_feeding.py
+++ b/tests/test_bottle_feeding.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import time
+from datetime import datetime, timedelta, timezone
 
 from google.cloud import firestore
 
@@ -10,6 +11,17 @@ from huckleberry_api import HuckleberryAPI
 
 class TestBottleFeeding:
     """Test bottle feeding functionality."""
+
+    async def _next_bottle_start_time(self, api: HuckleberryAPI, child_uid: str) -> datetime:
+        """Return a bottle timestamp newer than the current latest summary."""
+        db = await api._get_firestore_client()
+        feed_doc = await db.collection("feed").document(child_uid).get()
+        data = feed_doc.to_dict() or {}
+        last_bottle = ((data.get("prefs") or {}).get("lastBottle") or {}).get("start")
+        minimum_start = time.time()
+        if isinstance(last_bottle, int | float):
+            minimum_start = max(minimum_start, float(last_bottle) + 60.0)
+        return datetime.fromtimestamp(minimum_start, tz=timezone.utc).replace(microsecond=0)
 
     async def _find_recent_bottle_interval(
         self,
@@ -59,8 +71,9 @@ class TestBottleFeeding:
     async def test_log_bottle_formula(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test logging formula bottle feeding."""
         # Log formula bottle
+        start_time = await self._next_bottle_start_time(api, child_uid)
         created_after = time.time()
-        await api.log_bottle(child_uid, amount=120.0, bottle_type="Formula", units="ml")
+        await api.log_bottle(child_uid, start_time=start_time, amount=120.0, bottle_type="Formula", units="ml")
         await asyncio.sleep(2)
 
         interval_data = await self._find_recent_bottle_interval(
@@ -86,6 +99,7 @@ class TestBottleFeeding:
         assert data is not None
         prefs = data.get("prefs", {})
         assert "lastBottle" in prefs
+        assert prefs["lastBottle"]["start"] == start_time.timestamp()
         assert prefs["lastBottle"]["mode"] == "bottle"
         assert prefs["lastBottle"]["bottleType"] == "Formula"
         assert prefs["lastBottle"]["bottleAmount"] == 120.0
@@ -94,8 +108,9 @@ class TestBottleFeeding:
     async def test_log_bottle_breast_milk(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test logging breast milk bottle feeding."""
         # Log breast milk bottle
+        start_time = await self._next_bottle_start_time(api, child_uid)
         created_after = time.time()
-        await api.log_bottle(child_uid, amount=90.0, bottle_type="Breast Milk", units="ml")
+        await api.log_bottle(child_uid, start_time=start_time, amount=90.0, bottle_type="Breast Milk", units="ml")
         await asyncio.sleep(2)
 
         interval_data = await self._find_recent_bottle_interval(
@@ -114,8 +129,9 @@ class TestBottleFeeding:
     async def test_log_bottle_ounces(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test logging bottle feeding with ounces."""
         # Log with oz units
+        start_time = await self._next_bottle_start_time(api, child_uid)
         created_after = time.time()
-        await api.log_bottle(child_uid, amount=4.0, bottle_type="Formula", units="oz")
+        await api.log_bottle(child_uid, start_time=start_time, amount=4.0, bottle_type="Formula", units="oz")
         await asyncio.sleep(2)
 
         interval_data = await self._find_recent_bottle_interval(
@@ -132,8 +148,9 @@ class TestBottleFeeding:
     async def test_log_bottle_cow_milk(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test logging cow milk bottle feeding."""
         # Log cow milk bottle
+        start_time = await self._next_bottle_start_time(api, child_uid)
         created_after = time.time()
-        await api.log_bottle(child_uid, amount=100.0, bottle_type="Cow Milk", units="ml")
+        await api.log_bottle(child_uid, start_time=start_time, amount=100.0, bottle_type="Cow Milk", units="ml")
         await asyncio.sleep(2)
 
         interval_data = await self._find_recent_bottle_interval(
@@ -151,8 +168,9 @@ class TestBottleFeeding:
     async def test_log_bottle_default_params(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test logging bottle feeding with default parameters."""
         # Log with defaults (Formula, ml)
+        start_time = await self._next_bottle_start_time(api, child_uid)
         created_after = time.time()
-        await api.log_bottle(child_uid, amount=150.0)
+        await api.log_bottle(child_uid, start_time=start_time, amount=150.0)
         await asyncio.sleep(2)
 
         interval_data = await self._find_recent_bottle_interval(
@@ -171,7 +189,14 @@ class TestBottleFeeding:
     async def test_bottle_feeding_updates_prefs(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test that bottle feeding updates document-level preferences."""
         # Log bottle feeding
-        await api.log_bottle(child_uid, amount=110.0, bottle_type="Breast Milk", units="oz")
+        start_time = await self._next_bottle_start_time(api, child_uid)
+        await api.log_bottle(
+            child_uid,
+            start_time=start_time,
+            amount=110.0,
+            bottle_type="Breast Milk",
+            units="oz",
+        )
         await asyncio.sleep(2)
 
         # Check document-level prefs updated
@@ -182,6 +207,7 @@ class TestBottleFeeding:
         prefs = data.get("prefs", {})
 
         # Check document-level defaults
+        assert prefs.get("lastBottle", {}).get("start") == start_time.timestamp()
         assert prefs.get("bottleType") == "Breast Milk"
         assert prefs.get("bottleAmount") == 110.0
         assert prefs.get("bottleUnits") == "oz"
@@ -191,3 +217,62 @@ class TestBottleFeeding:
         assert prefs["lastBottle"]["bottleType"] == "Breast Milk"
         assert prefs["lastBottle"]["bottleAmount"] == 110.0
         assert prefs["lastBottle"]["bottleUnits"] == "oz"
+
+    async def test_log_bottle_with_explicit_start_time(self, api: HuckleberryAPI, child_uid: str) -> None:
+        """Test logging bottle feeding at an explicit past timestamp."""
+        start_time = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=2)
+
+        await api.log_bottle(
+            child_uid,
+            start_time=start_time,
+            amount=75.0,
+            bottle_type="Formula",
+            units="ml",
+        )
+        await asyncio.sleep(1)
+
+        db = await api._get_firestore_client()
+        intervals_ref = db.collection("feed").document(child_uid).collection("intervals")
+        matching = list(
+            await intervals_ref.where(filter=firestore.FieldFilter("start", "==", start_time.timestamp())).get()
+        )
+        bottle_entries = [doc.to_dict() for doc in matching if (doc.to_dict() or {}).get("mode") == "bottle"]
+
+        assert bottle_entries
+        interval_data = bottle_entries[0]
+        assert interval_data is not None
+        assert interval_data["amount"] == 75.0
+        assert interval_data["bottleType"] == "Formula"
+
+    async def test_older_bottle_entry_does_not_replace_latest_summary(
+        self, api: HuckleberryAPI, child_uid: str
+    ) -> None:
+        """Test that backfilled bottle entries do not overwrite the latest bottle summary."""
+        newer_start = await self._next_bottle_start_time(api, child_uid)
+        older_start = newer_start - timedelta(hours=4)
+
+        await api.log_bottle(
+            child_uid,
+            start_time=newer_start,
+            amount=120.0,
+            bottle_type="Breast Milk",
+            units="ml",
+        )
+        await asyncio.sleep(1)
+        await api.log_bottle(
+            child_uid,
+            start_time=older_start,
+            amount=60.0,
+            bottle_type="Formula",
+            units="ml",
+        )
+        await asyncio.sleep(1)
+
+        db = await api._get_firestore_client()
+        feed_doc = await db.collection("feed").document(child_uid).get()
+        data = feed_doc.to_dict() or {}
+        last_bottle = (data.get("prefs") or {}).get("lastBottle") or {}
+
+        assert last_bottle.get("start") == newer_start.timestamp()
+        assert last_bottle.get("bottleType") == "Breast Milk"
+        assert last_bottle.get("bottleAmount") == 120.0

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -74,7 +74,7 @@ class TestCalendarIntervals:
     async def test_list_diaper_intervals(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test fetching diaper intervals for a date range."""
         # Create a diaper entry first
-        await api.log_diaper(child_uid, mode="pee")
+        await api.log_diaper(child_uid, start_time=datetime.now(timezone.utc).replace(microsecond=0), mode="pee")
         await asyncio.sleep(1)
 
         # Query for intervals in the last hour
@@ -95,7 +95,12 @@ class TestCalendarIntervals:
     async def test_list_health_entries(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test fetching health/growth entries for a date range."""
         # Create a health entry first
-        await api.log_growth(child_uid, weight=5.0, units="metric")
+        await api.log_growth(
+            child_uid,
+            start_time=datetime.now(timezone.utc).replace(microsecond=0),
+            weight=5.0,
+            units="metric",
+        )
         await asyncio.sleep(1)
 
         # Query for entries in the last hour

--- a/tests/test_diaper.py
+++ b/tests/test_diaper.py
@@ -1,6 +1,9 @@
 """Diaper tracking tests for Huckleberry API."""
 
 import asyncio
+from datetime import datetime, timedelta, timezone
+
+from google.cloud import firestore
 
 from huckleberry_api import HuckleberryAPI
 
@@ -10,7 +13,12 @@ class TestDiaperTracking:
 
     async def test_log_diaper_pee(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test logging pee-only diaper change."""
-        await api.log_diaper(child_uid, mode="pee", pee_amount="medium")
+        await api.log_diaper(
+            child_uid,
+            start_time=datetime.now(timezone.utc).replace(microsecond=0),
+            mode="pee",
+            pee_amount="medium",
+        )
         await asyncio.sleep(1)
 
         # Verify it was logged
@@ -23,7 +31,14 @@ class TestDiaperTracking:
 
     async def test_log_diaper_poo(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test logging poo-only diaper change."""
-        await api.log_diaper(child_uid, mode="poo", poo_amount="big", color="yellow", consistency="solid")
+        await api.log_diaper(
+            child_uid,
+            start_time=datetime.now(timezone.utc).replace(microsecond=0),
+            mode="poo",
+            poo_amount="big",
+            color="yellow",
+            consistency="solid",
+        )
         await asyncio.sleep(1)
 
         db = await api._get_firestore_client()
@@ -35,7 +50,13 @@ class TestDiaperTracking:
     async def test_log_diaper_both(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test logging both pee and poo."""
         await api.log_diaper(
-            child_uid, mode="both", pee_amount="medium", poo_amount="medium", color="green", consistency="runny"
+            child_uid,
+            start_time=datetime.now(timezone.utc).replace(microsecond=0),
+            mode="both",
+            pee_amount="medium",
+            poo_amount="medium",
+            color="green",
+            consistency="runny",
         )
         await asyncio.sleep(1)
 
@@ -47,7 +68,7 @@ class TestDiaperTracking:
 
     async def test_log_diaper_dry(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test logging dry diaper check."""
-        await api.log_diaper(child_uid, mode="dry")
+        await api.log_diaper(child_uid, start_time=datetime.now(timezone.utc).replace(microsecond=0), mode="dry")
         await asyncio.sleep(1)
 
         db = await api._get_firestore_client()
@@ -60,6 +81,7 @@ class TestDiaperTracking:
         """Test logging a potty event into the shared diaper tracker."""
         await api.log_potty(
             child_uid,
+            start_time=datetime.now(timezone.utc).replace(microsecond=0),
             mode="poo",
             how_it_happened="wentPotty",
             poo_amount="medium",
@@ -83,3 +105,47 @@ class TestDiaperTracking:
         assert latest is not None
         assert latest["isPotty"] is True
         assert latest["howItHappened"] == "wentPotty"
+
+    async def test_log_diaper_with_explicit_start_time(self, api: HuckleberryAPI, child_uid: str) -> None:
+        """Test logging a diaper change with an explicit past timestamp."""
+        start_time = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=2)
+
+        await api.log_diaper(child_uid, start_time=start_time, mode="pee", pee_amount="little")
+        await asyncio.sleep(1)
+
+        db = await api._get_firestore_client()
+        intervals_ref = db.collection("diaper").document(child_uid).collection("intervals")
+        matching = list(
+            await intervals_ref.where(filter=firestore.FieldFilter("start", "==", start_time.timestamp())).get()
+        )
+
+        assert matching
+        interval_data = matching[0].to_dict()
+        assert interval_data is not None
+        assert interval_data["start"] == start_time.timestamp()
+        assert interval_data["mode"] == "pee"
+
+    async def test_log_potty_with_explicit_start_time(self, api: HuckleberryAPI, child_uid: str) -> None:
+        """Test logging a potty event with an explicit past timestamp."""
+        start_time = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=3)
+
+        await api.log_potty(
+            child_uid,
+            start_time=start_time,
+            mode="pee",
+            how_it_happened="accident",
+            pee_amount="little",
+        )
+        await asyncio.sleep(1)
+
+        db = await api._get_firestore_client()
+        intervals_ref = db.collection("diaper").document(child_uid).collection("intervals")
+        matching = list(
+            await intervals_ref.where(filter=firestore.FieldFilter("start", "==", start_time.timestamp())).get()
+        )
+        potty_entries = [doc.to_dict() for doc in matching if (doc.to_dict() or {}).get("isPotty") is True]
+
+        assert potty_entries
+        interval_data = potty_entries[0]
+        assert interval_data is not None
+        assert interval_data["howItHappened"] == "accident"

--- a/tests/test_feeding.py
+++ b/tests/test_feeding.py
@@ -1,6 +1,8 @@
 """Feeding tracking tests for Huckleberry API."""
 
 import asyncio
+import time
+from datetime import datetime, timedelta, timezone
 
 from google.cloud import firestore
 
@@ -123,6 +125,7 @@ class TestFeedingTracking:
     async def test_complete_feeding_creates_interval(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test that completing feeding creates interval document."""
         # Start and complete nursing
+        created_after = time.time()
         await api.start_nursing(child_uid, side="left")
         await asyncio.sleep(3)
         await api.complete_nursing(child_uid)
@@ -133,14 +136,43 @@ class TestFeedingTracking:
         # Check intervals subcollection
         intervals_ref = db.collection("feed").document(child_uid).collection("intervals")
 
-        # Get most recent interval
-        recent_intervals = intervals_ref.order_by("start", direction=firestore.Query.DESCENDING).limit(1)
+        recent_intervals = intervals_ref.order_by("lastUpdated", direction=firestore.Query.DESCENDING).limit(10)
 
         intervals_list = list(await recent_intervals.get())
         assert len(intervals_list) > 0
 
-        interval_data = intervals_list[0].to_dict()
+        interval_data = next(
+            (
+                data
+                for doc in intervals_list
+                if (data := doc.to_dict())
+                and data.get("mode") == "breast"
+                and float(data.get("lastUpdated", 0.0)) >= created_after
+            ),
+            None,
+        )
         assert interval_data is not None
         assert "start" in interval_data
         assert "mode" in interval_data
         assert interval_data["mode"] == "breast"
+
+    async def test_log_nursing_with_explicit_times(self, api: HuckleberryAPI, child_uid: str) -> None:
+        """Test logging a completed nursing interval with explicit timestamps."""
+        end_time = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=3)
+        start_time = end_time - timedelta(minutes=40)
+
+        await api.log_nursing(child_uid, start_time=start_time, end_time=end_time, side="right")
+        await asyncio.sleep(1)
+
+        db = await api._get_firestore_client()
+        intervals_ref = db.collection("feed").document(child_uid).collection("intervals")
+        matching = list(
+            await intervals_ref.where(filter=firestore.FieldFilter("start", "==", start_time.timestamp())).get()
+        )
+
+        breast_entries = [doc.to_dict() for doc in matching if (doc.to_dict() or {}).get("mode") == "breast"]
+        assert breast_entries
+        interval_data = breast_entries[0]
+        assert interval_data is not None
+        assert interval_data["lastSide"] == "right"
+        assert interval_data["rightDuration"] == (end_time - start_time).total_seconds()

--- a/tests/test_growth.py
+++ b/tests/test_growth.py
@@ -1,6 +1,9 @@
 """Growth tracking tests for Huckleberry API."""
 
 import asyncio
+from datetime import datetime, timedelta, timezone
+
+from google.cloud import firestore
 
 from huckleberry_api import HuckleberryAPI
 
@@ -10,7 +13,14 @@ class TestGrowthTracking:
 
     async def test_log_growth_metric(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test logging growth measurement in metric units."""
-        await api.log_growth(child_uid, weight=5.2, height=52.0, head=35.0, units="metric")
+        await api.log_growth(
+            child_uid,
+            start_time=datetime.now(timezone.utc).replace(microsecond=0),
+            weight=5.2,
+            height=52.0,
+            head=35.0,
+            units="metric",
+        )
         await asyncio.sleep(1)
 
         # Verify it was logged by checking health collection
@@ -22,7 +32,13 @@ class TestGrowthTracking:
 
     async def test_log_growth_imperial(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test logging supported imperial growth measurements."""
-        await api.log_growth(child_uid, weight=11.5, head=13.8, units="imperial")
+        await api.log_growth(
+            child_uid,
+            start_time=datetime.now(timezone.utc).replace(microsecond=0),
+            weight=11.5,
+            head=13.8,
+            units="imperial",
+        )
         await asyncio.sleep(1)
 
         db = await api._get_firestore_client()
@@ -51,3 +67,20 @@ class TestGrowthTracking:
             assert growth_data.heightUnits in ("cm", "ft.in")
         if growth_data.headUnits is not None:
             assert growth_data.headUnits in ("hcm", "hin")
+
+    async def test_log_growth_with_explicit_start_time(self, api: HuckleberryAPI, child_uid: str) -> None:
+        """Test logging growth with an explicit past timestamp."""
+        start_time = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=5)
+
+        await api.log_growth(child_uid, start_time=start_time, weight=6.1, units="metric")
+        await asyncio.sleep(1)
+
+        db = await api._get_firestore_client()
+        data_ref = db.collection("health").document(child_uid).collection("data")
+        matching = list(await data_ref.where(filter=firestore.FieldFilter("start", "==", start_time.timestamp())).get())
+
+        assert matching
+        growth_data = matching[0].to_dict()
+        assert growth_data is not None
+        assert growth_data["start"] == start_time.timestamp()
+        assert growth_data["weight"] == 6.1

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -73,6 +73,7 @@ class TestRealtimeListeners:
 
         await api.log_solids(
             child_uid,
+            start_time=datetime.now(timezone.utc).replace(microsecond=0),
             foods=[
                 SolidsFoodReference(
                     id=curated[0].id,
@@ -156,7 +157,12 @@ class TestRealtimeListeners:
         await api.setup_health_listener(child_uid, callback)
         await asyncio.sleep(2)
 
-        await api.log_growth(child_uid, weight=5.5, units="metric")
+        await api.log_growth(
+            child_uid,
+            start_time=datetime.now(timezone.utc).replace(microsecond=0),
+            weight=5.5,
+            units="metric",
+        )
         await asyncio.sleep(2)
 
         await api.stop_all_listeners()
@@ -176,7 +182,13 @@ class TestRealtimeListeners:
         await api.setup_health_listener(child_uid, callback)
         await asyncio.sleep(2)
 
-        await api.log_growth(child_uid, weight=11.5, head=13.8, units="imperial")
+        await api.log_growth(
+            child_uid,
+            start_time=datetime.now(timezone.utc).replace(microsecond=0),
+            weight=11.5,
+            head=13.8,
+            units="imperial",
+        )
         await asyncio.sleep(2)
 
         await api.stop_all_listeners()
@@ -209,7 +221,7 @@ class TestRealtimeListeners:
         await api.setup_diaper_listener(child_uid, callback)
         await asyncio.sleep(2)
 
-        await api.log_diaper(child_uid, mode="pee")
+        await api.log_diaper(child_uid, start_time=datetime.now(timezone.utc).replace(microsecond=0), mode="pee")
         await asyncio.sleep(2)
 
         await api.stop_all_listeners()
@@ -229,7 +241,13 @@ class TestRealtimeListeners:
         await api.setup_diaper_listener(child_uid, callback)
         await asyncio.sleep(2)
 
-        await api.log_potty(child_uid, mode="pee", how_it_happened="accident", pee_amount="little")
+        await api.log_potty(
+            child_uid,
+            start_time=datetime.now(timezone.utc).replace(microsecond=0),
+            mode="pee",
+            how_it_happened="accident",
+            pee_amount="little",
+        )
         await asyncio.sleep(2)
 
         await api.stop_all_listeners()

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -1,6 +1,7 @@
 """Sleep tracking tests for Huckleberry API."""
 
 import asyncio
+from datetime import datetime, timedelta, timezone
 
 from google.cloud import firestore
 
@@ -97,3 +98,23 @@ class TestSleepTracking:
         assert "start" in interval_data
         assert "duration" in interval_data
         assert interval_data["duration"] >= 3  # At least 3 seconds
+
+    async def test_log_sleep_with_explicit_times(self, api: HuckleberryAPI, child_uid: str) -> None:
+        """Test logging a completed sleep interval with explicit start and end times."""
+        end_time = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=2)
+        start_time = end_time - timedelta(minutes=95)
+
+        await api.log_sleep(child_uid, start_time=start_time, end_time=end_time)
+        await asyncio.sleep(1)
+
+        db = await api._get_firestore_client()
+        intervals_ref = db.collection("sleep").document(child_uid).collection("intervals")
+        matching = list(
+            await intervals_ref.where(filter=firestore.FieldFilter("start", "==", int(start_time.timestamp()))).get()
+        )
+
+        assert matching
+        interval_data = matching[0].to_dict()
+        assert interval_data is not None
+        assert interval_data["start"] == int(start_time.timestamp())
+        assert interval_data["duration"] == int((end_time - start_time).total_seconds())

--- a/tests/test_solids.py
+++ b/tests/test_solids.py
@@ -3,6 +3,7 @@
 import asyncio
 import time
 from datetime import datetime, timedelta, timezone
+from typing import cast
 
 from google.cloud import firestore
 
@@ -13,6 +14,55 @@ from huckleberry_api.models import SolidsFoodReference
 
 class TestSolidsFeeding:
     """Test solid food feeding functionality."""
+
+    async def _next_solids_start_time(self, api: HuckleberryAPI, child_uid: str) -> datetime:
+        """Return a solids timestamp newer than the current latest summary."""
+        db = await api._get_firestore_client()
+        feed_doc = await db.collection("feed").document(child_uid).get()
+        data = feed_doc.to_dict() or {}
+        last_solid = ((data.get("prefs") or {}).get("lastSolid") or {}).get("start")
+        minimum_start = time.time()
+        if isinstance(last_solid, int | float):
+            minimum_start = max(minimum_start, float(last_solid) + 60.0)
+        return datetime.fromtimestamp(minimum_start, tz=timezone.utc).replace(microsecond=0)
+
+    async def _find_recent_solids_interval(
+        self,
+        api: HuckleberryAPI,
+        child_uid: str,
+        *,
+        start_timestamp: float,
+        food_count: int,
+        notes: str | None = None,
+        reactions: dict[str, bool] | None = None,
+    ) -> dict[str, object]:
+        """Find the solids interval written by the current test."""
+        db = await api._get_firestore_client()
+        intervals_ref = db.collection("feed").document(child_uid).collection("intervals")
+
+        for _ in range(10):
+            intervals_list = list(
+                await intervals_ref.where(filter=firestore.FieldFilter("start", "==", start_timestamp)).get()
+            )
+
+            for interval_doc in intervals_list:
+                interval_data = interval_doc.to_dict()
+                if not interval_data or interval_data.get("mode") != "solids":
+                    continue
+
+                foods = interval_data.get("foods")
+                if not isinstance(foods, dict) or len(foods) != food_count:
+                    continue
+                if notes is not None and interval_data.get("notes") != notes:
+                    continue
+                if reactions is not None and interval_data.get("reactions") != reactions:
+                    continue
+
+                return interval_data
+
+            await asyncio.sleep(0.5)
+
+        raise AssertionError("No matching recent solids interval found")
 
     async def test_get_curated_foods(self, api: HuckleberryAPI) -> None:
         """Test fetching curated solids catalog."""
@@ -40,23 +90,22 @@ class TestSolidsFeeding:
         """Test logging solids with an existing curated food ID."""
         curated = await api.list_solids_curated_foods()
         assert curated
+        start_time = await self._next_solids_start_time(api, child_uid)
 
         await api.log_solids(
             child_uid,
+            start_time=start_time,
             foods=[SolidsFoodReference(id=curated[0].id, source="curated", name=curated[0].name, amount="small")],
         )
         await asyncio.sleep(2)
 
         db = await api._get_firestore_client()
-
-        intervals_ref = db.collection("feed").document(child_uid).collection("intervals")
-
-        recent_intervals = intervals_ref.order_by("start", direction=firestore.Query.DESCENDING).limit(1)
-
-        intervals_list = list(await recent_intervals.get())
-        assert len(intervals_list) > 0
-
-        data = intervals_list[0].to_dict()
+        data = await self._find_recent_solids_interval(
+            api,
+            child_uid,
+            start_timestamp=start_time.timestamp(),
+            food_count=1,
+        )
         assert data is not None
         assert data["mode"] == "solids"
         assert "start" in data
@@ -72,8 +121,9 @@ class TestSolidsFeeding:
 
         # Check foods structure
         foods = data["foods"]
+        assert isinstance(foods, dict)
         assert len(foods) == 1
-        food_entry = next(iter(foods.values()))
+        food_entry = cast(dict[str, object], next(iter(foods.values())))
         assert food_entry["source"] == "curated"
         assert isinstance(food_entry["created_name"], str)
         assert food_entry["created_name"]
@@ -83,9 +133,11 @@ class TestSolidsFeeding:
         custom_food = await api.create_solids_custom_food(child_uid, f"api-custom-{int(time.time())}")
         curated = await api.list_solids_curated_foods()
         assert len(curated) >= 2
+        start_time = await self._next_solids_start_time(api, child_uid)
 
         await api.log_solids(
             child_uid,
+            start_time=start_time,
             foods=[
                 SolidsFoodReference(id=curated[0].id, source="curated", name=curated[0].name, amount="small"),
                 SolidsFoodReference(id=curated[1].id, source="curated", name=curated[1].name, amount="medium"),
@@ -97,18 +149,19 @@ class TestSolidsFeeding:
         await asyncio.sleep(2)
 
         db = await api._get_firestore_client()
-
-        intervals_ref = db.collection("feed").document(child_uid).collection("intervals")
-
-        recent_intervals = intervals_ref.order_by("start", direction=firestore.Query.DESCENDING).limit(1)
-
-        intervals_list = list(await recent_intervals.get())
-        assert len(intervals_list) > 0
-
-        data = intervals_list[0].to_dict()
+        data = await self._find_recent_solids_interval(
+            api,
+            child_uid,
+            start_timestamp=start_time.timestamp(),
+            food_count=3,
+            notes="First time trying broccoli",
+            reactions={"LOVED": True},
+        )
         assert data is not None
         assert data["mode"] == "solids"
-        assert len(data["foods"]) == 3
+        foods = data["foods"]
+        assert isinstance(foods, dict)
+        assert len(foods) == 3
         assert data.get("notes") == "First time trying broccoli"
         assert data.get("reactions") == {"LOVED": True}
 
@@ -119,15 +172,36 @@ class TestSolidsFeeding:
         assert last_solid.get("reactions") == {"LOVED": True}
         assert isinstance(last_solid.get("foods"), dict)
 
-        sources = {v["source"] for v in data["foods"].values()}
-        assert "curated" in sources
-        assert "custom" in sources
+    async def test_log_solids_with_explicit_start_time(self, api: HuckleberryAPI, child_uid: str) -> None:
+        """Test logging solids with an explicit past timestamp."""
+        curated = await api.list_solids_curated_foods()
+        start_time = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=2)
+
+        await api.log_solids(
+            child_uid,
+            start_time=start_time,
+            foods=[SolidsFoodReference(id=curated[0].id, source="curated", name=curated[0].name, amount="small")],
+        )
+        await asyncio.sleep(1)
+
+        db = await api._get_firestore_client()
+        intervals_ref = db.collection("feed").document(child_uid).collection("intervals")
+        matching = list(
+            await intervals_ref.where(filter=firestore.FieldFilter("start", "==", start_time.timestamp())).get()
+        )
+        solids_entries = [doc.to_dict() for doc in matching if (doc.to_dict() or {}).get("mode") == "solids"]
+
+        assert solids_entries
+        interval_data = solids_entries[0]
+        assert interval_data is not None
+        assert interval_data["start"] == start_time.timestamp()
 
     async def test_solids_entries_are_in_feed_intervals(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test retrieving solids entries via feed intervals."""
         curated = await api.list_solids_curated_foods()
         await api.log_solids(
             child_uid,
+            start_time=datetime.now(timezone.utc).replace(microsecond=0),
             foods=[SolidsFoodReference(id=curated[0].id, source="curated", name=curated[0].name, amount="small")],
         )
         await asyncio.sleep(2)
@@ -145,6 +219,7 @@ class TestSolidsFeeding:
         curated = await api.list_solids_curated_foods()
         await api.log_solids(
             child_uid,
+            start_time=datetime.now(timezone.utc).replace(microsecond=0),
             foods=[SolidsFoodReference(id=curated[0].id, source="curated", name=curated[0].name, amount="small")],
         )
         await asyncio.sleep(2)


### PR DESCRIPTION
## Summary
- add explicit historical logging APIs for sleep and nursing
- require explicit `start_time` for bottle, solids, diaper, potty, and growth logging instead of falling back to the current time
- keep latest summary fields stable when backfilling older entries and replace remaining anonymous Firebase payloads with strict models
- update README, tests, and towncrier news for the breaking API changes

## Testing
- `uv run ruff check .`
- `uv run ty check --python-version 3.14 --ignore unknown-argument`
- `uv run pytest tests -q`