### PR TITLE
feat: Add in read-only API for SweetSpot

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ async def main() -> None:
 ### Children
 - `await get_user()` - Get full `users/{uid}` document
 - `await get_child(child_uid)` - Get a single child profile by id
+- `await get_sweetspot(child_uid)` - Get the child SweetSpot prediction payload when available
 
 ### Sleep Tracking
 - `await start_sleep(child_uid)` - Start sleep session

--- a/src/huckleberry_api/api.py
+++ b/src/huckleberry_api/api.py
@@ -33,6 +33,7 @@ from .firebase_types import (
     FirebaseBottleFeedIntervalData,
     FirebaseBreastFeedIntervalData,
     FirebaseChildDocument,
+    FirebaseChildSweetspot,
     FirebaseCuratedFoodDocument,
     FirebaseCustomFoodTypeDocument,
     FirebaseDiaperData,
@@ -360,6 +361,14 @@ class HuckleberryAPI:
         except (GoogleAPICallError, ValidationError, RuntimeError, TypeError, ValueError) as err:
             _LOGGER.error("Failed to get child %s: %s", child_uid, err)
             raise
+
+    async def get_sweetspot(self, child_uid: str) -> FirebaseChildSweetspot | None:
+        """Get the SweetSpot prediction payload for a child, if available."""
+        child = await self.get_child(child_uid)
+        if child is None:
+            return None
+
+        return child.sweetspot
 
     async def get_user(self) -> FirebaseUserDocument | None:
         """Get full users/{uid} document as strict Firebase model."""

--- a/src/huckleberry_api/firebase_types.py
+++ b/src/huckleberry_api/firebase_types.py
@@ -149,13 +149,60 @@ class FirebaseUserDocument(StrictModel):
 # ---------------------------------------------------------------------------
 
 
+SweetspotSource = Literal["ai_ml", "ai_ml_rl", "default"]
+
+
+class FirebaseChildSweetspotPrediction(StrictModel):
+    """SweetSpot prediction value nested under childs/{child_id}.sweetspot."""
+
+    best_by_date: Number
+    value: Number
+    source: SweetspotSource | None = None
+
+
+class FirebaseChildDisplayedSweetspotPrediction(StrictModel):
+    """Displayed SweetSpot prediction nested under childs/{child_id}.sweetspot.displayedSweetSpot."""
+
+    displayed_time: Number
+    source: SweetspotSource
+    timestamp: Number
+    value: Number
+
+
+class FirebaseChildSweetspotStrings(StrictModel):
+    """Localized/app-generated SweetSpot display strings."""
+
+    text1: str | None = None
+    text2: str | None = None
+    text3: str | None = None
+
+
 class FirebaseChildSweetspot(StrictModel):
     """Known payload for childs/{child_id}.sweetspot."""
 
+    ai: dict[str, dict[str, FirebaseChildSweetspotPrediction]] | None = None
+    displayedSweetSpot: dict[str, dict[str, FirebaseChildDisplayedSweetspotPrediction]] | None = None
     selectedNapDay: Number | None = None
+    shadowSweetSpotData: dict[str, dict[str, FirebaseChildSweetspotPrediction]] | None = None
     sweetSpotTimes: dict[str, Number] | None = None
-    # sweetspotStrings: FirebaseChildSweetspotStrings | None = None
+    sweetspotStrings: FirebaseChildSweetspotStrings | None = None
     uuid: str | None = None
+
+
+class FirebaseChildSweetspotAdjustmentWindow(StrictModel):
+    """Manual SweetSpot adjustment entry under childs/{child_id}.sweetspotAdjust.windows."""
+
+    absolute: Number
+    manual: bool
+    relative: Number
+
+
+class FirebaseChildSweetspotAdjustment(StrictModel):
+    """Known payload for childs/{child_id}.sweetspotAdjust."""
+
+    custom: bool
+    date_updated: Number
+    windows: dict[str, dict[str, FirebaseChildSweetspotAdjustmentWindow]]
 
 
 class FirebaseChildDocument(StrictModel):
@@ -172,6 +219,7 @@ class FirebaseChildDocument(StrictModel):
     morningCutoff: str | Number | None = None
     naps: str | None = None
     sweetspot: FirebaseChildSweetspot | None = None
+    sweetspotAdjust: FirebaseChildSweetspotAdjustment | None = None
     # analytics: Any | None = None
     pre: Number | None = None
     singleIntervalCount: Number | None = None

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -133,6 +133,20 @@ class TestChildrenRetrieval:
         assert child is not None
         assert child.model_dump(exclude_none=True)
 
+    async def test_get_sweetspot(self, api: HuckleberryAPI) -> None:
+        """Test retrieving child SweetSpot data by id when present."""
+        user_doc = await api.get_user()
+        assert user_doc is not None
+
+        child_uids = [child_ref.cid for child_ref in user_doc.childList]
+        assert child_uids
+
+        sweetspot = await api.get_sweetspot(child_uids[0])
+        if sweetspot is None:
+            return
+
+        assert sweetspot.model_dump(exclude_none=True)
+
 
 class TestErrorHandling:
     """Test error handling."""

--- a/tests/test_firebase_types.py
+++ b/tests/test_firebase_types.py
@@ -7,6 +7,8 @@ from huckleberry_api.firebase_types import (
     FirebaseActivityPrefs,
     FirebaseActivityTimerData,
     FirebaseActivityTimerEntryData,
+    FirebaseChildDocument,
+    FirebaseChildSweetspot,
     FirebaseDiaperDocumentData,
     FirebaseFeedDocumentData,
     FirebaseGrowthData,
@@ -19,6 +21,99 @@ from huckleberry_api.firebase_types import (
     FirebasePumpPrefs,
     FirebaseSleepDocumentData,
 )
+
+
+def test_child_sweetspot_model_accepts_known_payload() -> None:
+    """SweetSpot data is stored under childs/{child_uid}.sweetspot."""
+    model = FirebaseChildSweetspot.model_validate(
+        {
+            "ai": {
+                "5": {
+                    "W1": {
+                        "best_by_date": 1776716400.0,
+                        "source": "ai_ml_rl",
+                        "value": 1776712800.0,
+                    }
+                }
+            },
+            "displayedSweetSpot": {
+                "5": {
+                    "W1": {
+                        "displayed_time": 1776711000.0,
+                        "source": "ai_ml_rl",
+                        "timestamp": 1776711000.0,
+                        "value": 1776712800.0,
+                    }
+                }
+            },
+            "selectedNapDay": 3,
+            "shadowSweetSpotData": {
+                "2": {
+                    "W1": {
+                        "best_by_date": 1773179168.0,
+                        "value": 1773175568.0,
+                    }
+                }
+            },
+            "sweetSpotTimes": {
+                "1": 1773175568,
+                "2": 1773182768.5,
+            },
+            "sweetspotStrings": {
+                "text1": "Next nap",
+                "text2": None,
+                "text3": "SweetSpot",
+            },
+            "uuid": "abc123",
+        }
+    )
+
+    assert model.ai is not None
+    assert model.ai["5"]["W1"].source == "ai_ml_rl"
+    assert model.displayedSweetSpot is not None
+    assert model.displayedSweetSpot["5"]["W1"].source == "ai_ml_rl"
+    assert model.shadowSweetSpotData is not None
+    assert model.shadowSweetSpotData["2"]["W1"].source is None
+    assert model.selectedNapDay == 3
+    assert model.sweetSpotTimes == {"1": 1773175568, "2": 1773182768.5}
+    assert model.sweetspotStrings is not None
+    assert model.sweetspotStrings.text2 is None
+    assert model.uuid == "abc123"
+
+
+def test_child_document_accepts_sweetspot_payload() -> None:
+    """Child documents should expose SweetSpot payloads without loosening the root schema."""
+    model = FirebaseChildDocument.model_validate(
+        {
+            "childsName": "Test child",
+            "sweetspot": {
+                "selectedNapDay": 2,
+                "sweetSpotTimes": {
+                    "1": 1773175568,
+                },
+                "uuid": "def456",
+            },
+            "sweetspotAdjust": {
+                "custom": True,
+                "date_updated": 1773175568.0,
+                "windows": {
+                    "2": {
+                        "0": {
+                            "absolute": 1773179168.0,
+                            "manual": True,
+                            "relative": 1800.0,
+                        }
+                    }
+                },
+            },
+        }
+    )
+
+    assert model.sweetspot is not None
+    assert model.sweetspot.selectedNapDay == 2
+    assert model.sweetspot.sweetSpotTimes == {"1": 1773175568}
+    assert model.sweetspotAdjust is not None
+    assert model.sweetspotAdjust.windows["2"]["0"].manual is True
 
 
 def test_feed_document_accepts_empty_last_summary_maps() -> None:


### PR DESCRIPTION
Have added the Firebase API's for Sweetspot by interrogating Firestore. This is Read Only for now (I don't see what benefit write perms would give us for SweetSpot anyway).

Closes #8 