### PR TITLE
fix: reset _listener_client inside refresh_session_token

### DIFF
--- a/newsfragments/+listener-client-token-refresh.bugfix.md
+++ b/newsfragments/+listener-client-token-refresh.bugfix.md
@@ -1,0 +1,1 @@
+Reset the sync listener Firestore client (`_listener_client`) inside `refresh_session_token()` so that listeners recreated after a token refresh use new credentials. Without this, recreated listeners reused the old credentials and silently stopped receiving updates after the first token refresh (~1 hour).

--- a/src/huckleberry_api/api.py
+++ b/src/huckleberry_api/api.py
@@ -260,9 +260,14 @@ class HuckleberryAPI:
                 _LOGGER.error("Error stopping listener %s before refresh: %s", key, err)
         self._listeners.clear()
 
-        # Invalidate the Firestore client so it gets recreated with new token
+        # Invalidate both Firestore clients so they get recreated with new token.
+        # The async client is used for reads/writes; the sync client backs the
+        # snapshot listeners. Without resetting the sync client, recreated
+        # listeners reuse the old credentials and silently stop receiving
+        # updates after the first token refresh (~1 hour).
         self._firestore_client = None
         self._firestore_client_loop = None
+        self._listener_client = None
 
         _LOGGER.debug("Successfully refreshed authentication token")
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -3,10 +3,12 @@
 import asyncio
 import time
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import Mock
 
 import aiohttp
 import pytest
+from google.cloud import firestore
 
 from huckleberry_api import HuckleberryAPI
 
@@ -148,7 +150,7 @@ class TestAuthentication:
         api.id_token = "stale-id-token"
         api.refresh_token = "stale-refresh-token"
 
-        stale_listener_client = object()
+        stale_listener_client = cast(firestore.Client, object())
         unsubscribe = Mock()
         callback = Mock()
 
@@ -165,7 +167,7 @@ class TestAuthentication:
             assert child_uid == "child-123"
             assert received_callback is callback
             observed_listener_clients.append(api._listener_client)
-            api._listener_client = object()
+            api._listener_client = cast(firestore.Client, object())
 
         monkeypatch = pytest.MonkeyPatch()
         monkeypatch.setattr(websession, "post", fake_post)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -3,6 +3,7 @@
 import asyncio
 import time
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import aiohttp
 import pytest
@@ -115,6 +116,72 @@ class TestAuthentication:
         # Verify the refreshed token works by making a Firestore call
         user_doc = await api.get_user()
         assert user_doc is not None
+
+    async def test_refresh_session_token_recreates_listener_client(self, websession: aiohttp.ClientSession) -> None:
+        """Test token refresh drops the cached listener client before recreating listeners."""
+
+        class FakeResponse:
+            def __init__(self) -> None:
+                self.status = 200
+                self.reason = "OK"
+                self.headers = {}
+                self.request_info = SimpleNamespace(real_url="https://securetoken.googleapis.com/")
+                self.history = ()
+
+            async def __aenter__(self) -> FakeResponse:
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb) -> bool:
+                return False
+
+            async def text(self) -> str:
+                return '{"id_token":"fresh-id-token","refresh_token":"fresh-refresh-token","expires_in":"3600"}'
+
+            async def json(self, *args, **kwargs) -> dict[str, str]:
+                return {
+                    "id_token": "fresh-id-token",
+                    "refresh_token": "fresh-refresh-token",
+                    "expires_in": "3600",
+                }
+
+        api = HuckleberryAPI(email="listener@test.com", password="password", timezone="UTC", websession=websession)
+        api.id_token = "stale-id-token"
+        api.refresh_token = "stale-refresh-token"
+
+        stale_listener_client = object()
+        unsubscribe = Mock()
+        callback = Mock()
+
+        api._listener_client = stale_listener_client
+        api._listeners["sleep_child-123"] = SimpleNamespace(unsubscribe=unsubscribe)
+        api._listener_callbacks["sleep_child-123"] = ("sleep", "child-123", callback)
+
+        observed_listener_clients: list[object | None] = []
+
+        def fake_post(*args, **kwargs) -> FakeResponse:
+            return FakeResponse()
+
+        async def fake_setup_sleep_listener(child_uid: str, received_callback) -> None:
+            assert child_uid == "child-123"
+            assert received_callback is callback
+            observed_listener_clients.append(api._listener_client)
+            api._listener_client = object()
+
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(websession, "post", fake_post)
+        monkeypatch.setattr(api, "setup_sleep_listener", fake_setup_sleep_listener)
+
+        try:
+            await api.refresh_session_token()
+        finally:
+            monkeypatch.undo()
+
+        unsubscribe.assert_called_once_with()
+        assert observed_listener_clients == [None]
+        assert api._listener_client is not None
+        assert api._listener_client is not stale_listener_client
+        assert api.id_token == "fresh-id-token"
+        assert api.refresh_token == "fresh-refresh-token"
 
 
 class TestChildrenRetrieval:

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -135,9 +135,15 @@ class TestRealtimeListeners:
         await asyncio.sleep(2)
 
         initial_count = len(updates)
+        original_listener_client = api._listener_client
+
+        assert original_listener_client is not None
 
         await api.refresh_session_token()
         await asyncio.sleep(2)
+
+        assert api._listener_client is not None
+        assert api._listener_client is not original_listener_client
 
         await api.start_sleep(child_uid)
         await asyncio.sleep(2)


### PR DESCRIPTION
## What

One-line fix in `refresh_session_token`: drop `self._listener_client` (the sync Firestore client backing snapshot listeners) alongside the existing `self._firestore_client` reset.

## Why

After a token refresh, the method:
1. Refreshes the Firebase ID token.
2. Stops all existing listeners (correct — they were authenticated with the now-expired token).
3. Clears `self._firestore_client` (the async client).
4. Recreates listeners by calling `setup_*_listener` for each entry in `_listener_callbacks`.

In step 4, every `_setup_listener` call hits the cached-client check at `api.py:1397`:

```python
if not self._listener_client:
    credentials = FirebaseTokenCredentials(self.id_token)
    self._listener_client = firestore.Client(...)
```

Because step 3 only nulls the **async** client, the sync `_listener_client` is still truthy — so the recreated listeners are attached to a `firestore.Client` instance that was built with the **old** `FirebaseTokenCredentials`. The listeners run, but receive no further updates from Firestore once the old token expires (~5 min after the refresh window ends).

Net effect: snapshot listeners go silent ~1h after process startup and only recover on a full restart. This was reported by users as the behavior described in [`Woyken/huckleberry-homeassistant` PR #20 review notes](https://github.com/Woyken/huckleberry-homeassistant/pull/20#issuecomment-4293342712) ("there was an issue with refreshing token").

## Fix

Mirror what `stop_all_listeners` already does at line 1483: clear `_listener_client` so the next `_setup_listener` call rebuilds it with fresh credentials.

```diff
         self._firestore_client = None
         self._firestore_client_loop = None
+        self._listener_client = None
```

## Tests

The existing `test_listener_survives_token_refresh` integration test in `tests/test_listeners.py` would catch this if it ran in CI, but it requires `HUCKLEBERRY_EMAIL`/`HUCKLEBERRY_PASSWORD` env vars and is skipped in the public CI matrix. I verified the fix manually against a real Huckleberry account via the downstream HA integration (the listeners now stay alive across the 1-hour refresh boundary).

Adding a unit test that asserts the reset would require mocking `firestore.Client` construction, which I left out to keep the diff minimal — happy to add one if you'd like.

## Towncrier fragment

Included `+listener-client-token-refresh.bugfix.md`.