### PR TITLE
fix: normalize millisecond feedStartTime in complete_nursing

### DIFF
--- a/src/huckleberry_api/api.py
+++ b/src/huckleberry_api/api.py
@@ -99,6 +99,22 @@ TDocumentData = TypeVar(
 
 _LOGGER = logging.getLogger(__name__)
 
+# Epoch seconds are ~1.8e9; values beyond this can only be milliseconds.
+_MS_EPOCH_THRESHOLD = 1e11
+
+
+def _ensure_epoch_seconds(value: float) -> float:
+    """Normalize an epoch value that may be in milliseconds to seconds.
+
+    The official iOS app writes feed `timer.feedStartTime` in milliseconds
+    (observed live, 2026-07), while library-started sessions store seconds.
+    History intervals must always use seconds; a millisecond value written
+    verbatim dates the entry ~56,000 years in the future and freezes the
+    official app's summary pages.
+    """
+    return value / 1000 if value > _MS_EPOCH_THRESHOLD else value
+
+
 _FEED_INTERVAL_ADAPTER = TypeAdapter(FirebaseFeedIntervalData)
 _HEALTH_ENTRY_ADAPTER = TypeAdapter(HealthDataEntry)
 _ACTIVITY_LAST_FIELD_BY_MODE: dict[ActivityMode, str] = {
@@ -946,8 +962,8 @@ class HuckleberryAPI:
             return
 
         now_time = time.time()
-        # timerStartTime is in seconds for feeding
-        timer_start_sec = float(timer_start)
+        # timerStartTime is in seconds for feeding (normalized defensively)
+        timer_start_sec = _ensure_epoch_seconds(float(timer_start))
 
         left_duration = timer.leftDuration or 0.0
         right_duration = timer.rightDuration or 0.0
@@ -965,7 +981,10 @@ class HuckleberryAPI:
         # Calculate total duration from accumulated durations
         total_duration = left_duration + right_duration
 
-        feed_start_time = timer.feedStartTime or timer_start_sec
+        # App-started sessions store feedStartTime in milliseconds.
+        feed_start_time = (
+            _ensure_epoch_seconds(float(timer.feedStartTime)) if timer.feedStartTime else timer_start_sec
+        )
 
         # Determine last side for history
         last_side_value = timer.activeSide or timer.lastSide or "right"

--- a/src/huckleberry_api/firebase_types.py
+++ b/src/huckleberry_api/firebase_types.py
@@ -502,7 +502,11 @@ class FirebaseFeedTimerData(StrictModel):
     local_timestamp: Number | None = None
     feedStartTime: Number | None = Field(
         default=None,
-        description="Feeding session start time in seconds since epoch.",
+        description=(
+            "Feeding session start time since epoch. Library-started sessions "
+            "store seconds; the official iOS app writes milliseconds (observed "
+            "live, 2026-07). Consumers must normalize before writing history."
+        ),
     )
     timerStartTime: Number | None = Field(
         default=None,

--- a/tests/test_feeding.py
+++ b/tests/test_feeding.py
@@ -4,6 +4,7 @@ import asyncio
 import time
 from datetime import datetime, timedelta, timezone
 
+import pytest
 from google.cloud import firestore
 
 from huckleberry_api import HuckleberryAPI
@@ -155,6 +156,49 @@ class TestFeedingTracking:
         assert "start" in interval_data
         assert "mode" in interval_data
         assert interval_data["mode"] == "breast"
+
+    async def test_complete_nursing_normalizes_ms_feed_start_time(
+        self, api: HuckleberryAPI, child_uid: str
+    ) -> None:
+        """App-started sessions store timer.feedStartTime in milliseconds; the
+        interval written on completion must still use epoch seconds.
+
+        Regression test for issue #51: the resulting future-dated interval
+        (year ~58000) freezes the official app's summary pages.
+        """
+        await api.start_nursing(child_uid, side="right")
+        await asyncio.sleep(2)
+
+        db = await api._get_firestore_client()
+        feed_ref = db.collection("feed").document(child_uid)
+
+        # Simulate the official iOS app having started this session: observed
+        # live (2026-07), the app writes feedStartTime in milliseconds.
+        start_ms = (time.time() - 60) * 1000
+        await feed_ref.update({"timer.feedStartTime": start_ms})
+
+        created_after = time.time()
+        await api.complete_nursing(child_uid)
+        await asyncio.sleep(2)
+
+        intervals_ref = feed_ref.collection("intervals")
+        recent = intervals_ref.order_by("lastUpdated", direction=firestore.Query.DESCENDING).limit(5)
+        interval_data = next(
+            (
+                data
+                for doc in await recent.get()
+                if (data := doc.to_dict())
+                and data.get("mode") == "breast"
+                and float(data.get("lastUpdated", 0.0)) >= created_after
+            ),
+            None,
+        )
+        assert interval_data is not None
+        assert interval_data["start"] == pytest.approx(start_ms / 1000, abs=1.0)
+
+        prefs = (await feed_ref.get()).to_dict()["prefs"]
+        assert prefs["lastNursing"]["start"] == pytest.approx(start_ms / 1000, abs=1.0)
+        assert prefs["lastSide"]["start"] == pytest.approx(start_ms / 1000, abs=1.0)
 
     async def test_log_nursing_with_explicit_times(self, api: HuckleberryAPI, child_uid: str) -> None:
         """Test logging a completed nursing interval with explicit timestamps."""


### PR DESCRIPTION
Fixes #51.

## Problem

`complete_nursing()` copies `timer.feedStartTime` verbatim into the history interval's `start` field (and `prefs.lastNursing.start` / `prefs.lastSide.start`), assuming seconds. When the nursing session was started by the official iOS app, that field holds **milliseconds** — the resulting interval is dated ~56,000 years in the future, which freezes the official app's summary pages (details and live evidence in #51).

## Fix

- New `_ensure_epoch_seconds()` helper: values beyond `1e11` (epoch seconds are ~1.8e9) are treated as milliseconds and divided by 1000 — mirroring the ms handling `complete_sleep()` already does.
- Applied to `feedStartTime` and (defensively) `timerStartTime` in `complete_nursing()`. Library-started sessions (seconds) are unchanged.
- Updated the `FirebaseFeedTimerData.feedStartTime` field description per the schema-discovery convention: the app writes ms, library writes seconds (observed live, 2026-07).

## Test

`test_complete_nursing_normalizes_ms_feed_start_time`: starts a session, overwrites `timer.feedStartTime` with a millisecond value (simulating an app-started session), completes, and asserts the interval + prefs `start` are in seconds.

Verified against live Firebase with a real account:
- before the fix the new test fails with `start = 1783888523698.3445` (ms) written to history;
- after the fix it passes, and the pre-existing `test_complete_feeding_creates_interval` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
