### PR TITLE
fix: allow bottle feed intervals to omit `amount`

### DIFF
--- a/newsfragments/+bottle-feed-optional-amount.bugfix.md
+++ b/newsfragments/+bottle-feed-optional-amount.bugfix.md
@@ -1,0 +1,1 @@
+Allow `feed/{child_uid}/intervals` bottle rows to omit `amount`, so feeds saved without a volume validate instead of failing the whole `list_feed_intervals` query.

--- a/src/huckleberry_api/firebase_types.py
+++ b/src/huckleberry_api/firebase_types.py
@@ -556,7 +556,9 @@ class FirebaseBottleFeedIntervalData(StrictModel):
     start: Number
     lastUpdated: Number | None = None
     bottleType: BottleType
-    amount: Number
+    # Live bottle rows can omit `amount` entirely while still carrying
+    # `bottleType` and `units`, when the feed was saved without a volume.
+    amount: Number | None = None
     units: VolumeUnits
     offset: Number
     end_offset: Number | None = None

--- a/tests/test_firebase_types.py
+++ b/tests/test_firebase_types.py
@@ -1,5 +1,7 @@
 """Unit tests for strict Firebase schema models."""
 
+from pydantic import TypeAdapter
+
 from huckleberry_api.firebase_types import (
     FirebaseActivityDocumentData,
     FirebaseActivityIntervalData,
@@ -7,9 +9,11 @@ from huckleberry_api.firebase_types import (
     FirebaseActivityPrefs,
     FirebaseActivityTimerData,
     FirebaseActivityTimerEntryData,
+    FirebaseBottleFeedIntervalData,
     FirebaseChildDocument,
     FirebaseDiaperDocumentData,
     FirebaseFeedDocumentData,
+    FirebaseFeedIntervalData,
     FirebaseGrowthData,
     FirebaseLastActivityData,
     FirebaseLastPumpData,
@@ -136,6 +140,64 @@ def test_medication_model_accepts_live_app_ounce_units() -> None:
     )
 
     assert model.units == "oz"
+
+
+def test_bottle_feed_interval_accepts_missing_amount() -> None:
+    """Bottle rows saved without a volume omit `amount` entirely.
+
+    Payload copied from a live `feed/{child_uid}/intervals` document.
+    """
+    model = FirebaseBottleFeedIntervalData.model_validate(
+        {
+            "mode": "bottle",
+            "start": 1785513600.0,
+            "lastUpdated": 1785517038.669,
+            "bottleType": "Formula",
+            "units": "ml",
+            "offset": -60.0,
+        }
+    )
+
+    assert model.amount is None
+    assert model.units == "ml"
+    assert model.bottleType == "Formula"
+
+
+def test_feed_interval_union_resolves_bottle_without_amount() -> None:
+    """The union must still pick the bottle member when `amount` is absent.
+
+    This is the path `list_feed_intervals` takes, and where a required
+    `amount` surfaced: the row matched no union member, so the whole query
+    failed rather than just the one document.
+    """
+    model = TypeAdapter(FirebaseFeedIntervalData).validate_python(
+        {
+            "mode": "bottle",
+            "start": 1785513600.0,
+            "bottleType": "Formula",
+            "units": "ml",
+            "offset": -60.0,
+        }
+    )
+
+    assert isinstance(model, FirebaseBottleFeedIntervalData)
+    assert model.amount is None
+
+
+def test_bottle_feed_interval_still_accepts_an_amount() -> None:
+    """Making `amount` optional must not stop it being read when present."""
+    model = FirebaseBottleFeedIntervalData.model_validate(
+        {
+            "mode": "bottle",
+            "start": 1785513600.0,
+            "bottleType": "Breast Milk",
+            "amount": 60.0,
+            "units": "ml",
+            "offset": -60.0,
+        }
+    )
+
+    assert model.amount == 60.0
 
 
 def test_child_sweetspot_times_accepts_null_slots() -> None:


### PR DESCRIPTION
The app lets you save a bottle feed without entering a volume. The resulting document in `feed/{child_uid}/intervals` omits `amount` entirely while still carrying `bottleType` and `units`:

    {"mode": "bottle", "start": 1785513600.0, "lastUpdated": 1785517038.669,
     "bottleType": "Formula", "units": "ml", "offset": -60.0}

`FirebaseBottleFeedIntervalData.amount` is currently required, so such a row matches no member of the `FirebaseFeedIntervalData` union and `_FEED_INTERVAL_ADAPTER.validate_python` raises.

The impact is larger than one skipped row. `list_feed_intervals` wraps its whole iteration in a single `try/except (GoogleAPICallError, ValidationError)`, so the first amount-less bottle aborts the loop and the call returns only the entries gathered before it -- silently, since the error is logged rather than raised. One such feed can therefore hide every later feed in the range.

Makes `amount` optional, matching the live payload, and documents the finding on the field as per AGENTS.md. Same shape as the 0.4.3 `sweetSpotTimes` fix.

Tests: the exact live payload above, the union resolving to the bottle member without `amount`, and a bottle that still reads `amount` when present.