### PR TITLE
Add revision-safe history mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is a reverse-engineered API client that connects directly to Huckleberry's 
 - 🤱 **Pumping Tracking**: Log pumping sessions and fetch latest/history
 - 🧷 **Diaper Changes**: Log pee, poo, both, or dry checks with color/consistency
 - 📏 **Growth Measurements**: Record weight, height, and head circumference
+- ✏️ **Safe History Changes**: Edit or delete exact records with revision checks
 - 🔄 **Real-time Updates**: Firebase snapshot listeners for instant synchronization
 - 👶 **Child Management**: Support for multiple children profiles
 
@@ -185,6 +186,34 @@ async def main() -> None:
 - `await log_growth(child_uid, start_time=..., weight=..., height=..., head=..., units=...)` - Log measurements with an explicit event timestamp
   - `units`: "metric" (kg/cm) or "imperial" (lbs/inches)
 - `await get_latest_growth(child_uid)` - Get latest measurements
+
+### Revision-safe History Mutations
+
+History record list methods retain the Firestore document identity and update
+revision needed for safe edits and deletes:
+
+- `await list_sleep_interval_records(child_uid, start_time, end_time)`
+- `await list_feed_interval_records(child_uid, start_time, end_time)`
+- `await list_diaper_interval_records(child_uid, start_time, end_time)`
+- `await list_health_entry_records(child_uid, start_time, end_time)`
+
+Each returned record contains `reference` and `data`. Pass the unmodified
+`reference` to a mutation method:
+
+- `await update_sleep_interval(child_uid, reference, start_time=..., end_time=...)`
+- `await delete_sleep_interval(child_uid, reference)`
+- `await update_nursing_interval(child_uid, reference, start_time=..., left_duration=..., right_duration=..., last_side=...)`
+- `await update_bottle_interval(child_uid, reference, start_time=..., amount=..., bottle_type=..., units=...)`
+- `await delete_feed_interval(child_uid, reference)`
+- `await update_diaper_interval(child_uid, reference, start_time=..., mode=...)`
+- `await delete_diaper_interval(child_uid, reference)`
+- `await update_growth_entry(child_uid, reference, start_time=..., weight=..., height=..., head=..., units=...)`
+- `await delete_growth_entry(child_uid, reference)`
+
+Mutations run in a Firestore transaction. They reject stale revisions, support
+regular and batched history documents, and repair the affected `prefs.last*`
+cache atomically. List the record again after a successful edit before making
+another change because its revision will have changed.
 
 ### Real-time Listeners
 - `await setup_sleep_listener(child_uid, callback)` - Listen to sleep updates

--- a/newsfragments/+history-mutations.feature
+++ b/newsfragments/+history-mutations.feature
@@ -1,0 +1,1 @@
+Add stable history record references and revision-safe edit/delete methods for sleep, feeding, diaper, and growth records.

--- a/src/huckleberry_api/__init__.py
+++ b/src/huckleberry_api/__init__.py
@@ -3,5 +3,17 @@
 from __future__ import annotations
 
 from .api import HuckleberryAPI
+from .exceptions import (
+    HuckleberryRecordConflictError,
+    HuckleberryRecordError,
+    HuckleberryRecordNotFoundError,
+    HuckleberryRecordReferenceError,
+)
 
-__all__ = ["HuckleberryAPI"]
+__all__ = [
+    "HuckleberryAPI",
+    "HuckleberryRecordConflictError",
+    "HuckleberryRecordError",
+    "HuckleberryRecordNotFoundError",
+    "HuckleberryRecordReferenceError",
+]

--- a/src/huckleberry_api/api.py
+++ b/src/huckleberry_api/api.py
@@ -7,6 +7,7 @@ import json
 import logging
 import time
 import uuid
+from copy import deepcopy
 from datetime import datetime
 from datetime import timezone as dt_timezone
 from typing import Callable, Literal, TypeVar, cast
@@ -37,15 +38,19 @@ from .firebase_types import (
     FirebaseCustomFoodTypeDocument,
     FirebaseDiaperData,
     FirebaseDiaperDocumentData,
+    FirebaseDiaperIntervalRecord,
     FirebaseDiaperMultiContainer,
     FirebaseDiaperQuantity,
     FirebaseFeedDocumentData,
     FirebaseFeedIntervalData,
+    FirebaseFeedIntervalRecord,
     FirebaseFeedMultiContainer,
     FirebaseFeedTimerData,
     FirebaseGrowthData,
     FirebaseHealthDocumentData,
+    FirebaseHealthEntryRecord,
     FirebaseHealthMultiContainer,
+    FirebaseHistoryRecordReference,
     FirebaseLastActivityData,
     FirebaseLastBottleData,
     FirebaseLastDiaperData,
@@ -62,6 +67,7 @@ from .firebase_types import (
     FirebaseSleepDetails,
     FirebaseSleepDocumentData,
     FirebaseSleepIntervalData,
+    FirebaseSleepIntervalRecord,
     FirebaseSleepLocations,
     FirebaseSleepMultiContainer,
     FirebaseSleepTimerData,
@@ -80,10 +86,36 @@ from .firebase_types import (
     VolumeUnits,
     to_firebase_dict,
 )
+from .exceptions import (
+    HuckleberryRecordConflictError,
+    HuckleberryRecordNotFoundError,
+    HuckleberryRecordReferenceError,
+)
 from .models import SolidsFoodReference
 
 CURATED_FOODS_BUCKET = "simpleintervals.appspot.com"
 CURATED_FOODS_OBJECT = "foods/fooddb.json"
+
+type HistoryCollection = Literal["sleep", "feed", "diaper", "health"]
+type HistoryPreferenceKind = Literal[
+    "sleep",
+    "nursing",
+    "bottle",
+    "solids",
+    "diaper",
+    "potty",
+    "growth",
+]
+type RawHistoryData = dict[str, object]
+type HistoryCandidate = tuple[RawHistoryData, str, str | None]
+type HistoryMutator = Callable[[RawHistoryData, float], RawHistoryData | None]
+
+_HISTORY_SUBCOLLECTION: dict[HistoryCollection, Literal["intervals", "data"]] = {
+    "sleep": "intervals",
+    "feed": "intervals",
+    "diaper": "intervals",
+    "health": "data",
+}
 
 # Type variable for listener callback typing
 TDocumentData = TypeVar(
@@ -344,6 +376,24 @@ class HuckleberryAPI:
         if offset is None:
             return 0.0
         return -offset.total_seconds() / 60
+
+    def _get_timezone_offset_minutes_at(self, timestamp: float) -> float:
+        """Return the Huckleberry offset convention for a specific instant."""
+        offset = datetime.fromtimestamp(timestamp, self._timezone).utcoffset()
+        if offset is None:
+            return 0.0
+        return -offset.total_seconds() / 60
+
+    @staticmethod
+    def _history_record_reference(doc, entry_key: str | None = None) -> FirebaseHistoryRecordReference:
+        """Build an optimistic-concurrency reference from a Firestore snapshot."""
+        if doc.update_time is None:
+            raise HuckleberryRecordReferenceError("History document has no update revision")
+        return FirebaseHistoryRecordReference(
+            document_id=doc.id,
+            entry_key=entry_key,
+            revision=doc.update_time.isoformat(),
+        )
 
     async def get_child(self, child_uid: str) -> FirebaseChildDocument | None:
         """Get a single child document by child UID."""
@@ -2005,14 +2055,649 @@ class HuckleberryAPI:
             _LOGGER.error("Failed to get growth data: %s", err)
             return None
 
-    async def list_sleep_intervals(
+    @staticmethod
+    def _validate_history_revision(doc, reference: FirebaseHistoryRecordReference) -> None:
+        """Reject stale references before changing a history document."""
+        if doc.update_time is None:
+            raise HuckleberryRecordReferenceError("History document has no update revision")
+        if doc.update_time.isoformat() != reference.revision:
+            raise HuckleberryRecordConflictError("History record changed after it was read; list it again")
+
+    @staticmethod
+    def _extract_history_entry(
+        document_data: RawHistoryData,
+        reference: FirebaseHistoryRecordReference,
+    ) -> RawHistoryData:
+        """Resolve a regular or multi-container entry from one document snapshot."""
+        is_multi = document_data.get("multi") is True
+        if reference.entry_key is None:
+            if is_multi:
+                raise HuckleberryRecordReferenceError("Regular record reference points to a multi-entry document")
+            return deepcopy(document_data)
+
+        if not is_multi:
+            raise HuckleberryRecordReferenceError("Multi-entry reference points to a regular document")
+
+        entries = document_data.get("data")
+        if not isinstance(entries, dict):
+            raise HuckleberryRecordReferenceError("Multi-entry history document has no data map")
+        entries = cast(dict[str, object], entries)
+        entry = entries.get(reference.entry_key)
+        if not isinstance(entry, dict):
+            raise HuckleberryRecordNotFoundError("Referenced history entry no longer exists")
+        return deepcopy(cast(RawHistoryData, entry))
+
+    async def _get_history_record_data(
+        self,
+        collection_name: HistoryCollection,
+        child_uid: str,
+        reference: FirebaseHistoryRecordReference,
+    ) -> RawHistoryData:
+        """Read one exact history entry and verify its optimistic revision."""
+        client = await self._get_firestore_client()
+        document_ref = (
+            client.collection(collection_name)
+            .document(child_uid)
+            .collection(_HISTORY_SUBCOLLECTION[collection_name])
+            .document(reference.document_id)
+        )
+        doc = await document_ref.get()
+        if not doc.exists:
+            raise HuckleberryRecordNotFoundError("Referenced history document no longer exists")
+        self._validate_history_revision(doc, reference)
+        document_data = doc.to_dict()
+        if not document_data:
+            raise HuckleberryRecordNotFoundError("Referenced history document is empty")
+        return self._extract_history_entry(document_data, reference)
+
+    async def get_sleep_interval_record(
+        self,
+        child_uid: str,
+        reference: FirebaseHistoryRecordReference,
+    ) -> FirebaseSleepIntervalRecord:
+        """Read one exact sleep record, rejecting a stale reference."""
+        data = await self._get_history_record_data("sleep", child_uid, reference)
+        return FirebaseSleepIntervalRecord(reference=reference, data=FirebaseSleepIntervalData.model_validate(data))
+
+    async def get_feed_interval_record(
+        self,
+        child_uid: str,
+        reference: FirebaseHistoryRecordReference,
+    ) -> FirebaseFeedIntervalRecord:
+        """Read one exact feed record, rejecting a stale reference."""
+        data = await self._get_history_record_data("feed", child_uid, reference)
+        return FirebaseFeedIntervalRecord(reference=reference, data=_FEED_INTERVAL_ADAPTER.validate_python(data))
+
+    async def get_diaper_interval_record(
+        self,
+        child_uid: str,
+        reference: FirebaseHistoryRecordReference,
+    ) -> FirebaseDiaperIntervalRecord:
+        """Read one exact diaper record, rejecting a stale reference."""
+        data = await self._get_history_record_data("diaper", child_uid, reference)
+        return FirebaseDiaperIntervalRecord(reference=reference, data=FirebaseDiaperData.model_validate(data))
+
+    async def get_health_entry_record(
+        self,
+        child_uid: str,
+        reference: FirebaseHistoryRecordReference,
+    ) -> FirebaseHealthEntryRecord:
+        """Read one exact health record, rejecting a stale reference."""
+        data = await self._get_history_record_data("health", child_uid, reference)
+        return FirebaseHealthEntryRecord(reference=reference, data=_HEALTH_ENTRY_ADAPTER.validate_python(data))
+
+    @staticmethod
+    def _history_preference_kind(
+        collection_name: HistoryCollection,
+        entry: RawHistoryData,
+    ) -> HistoryPreferenceKind:
+        """Map a history payload to the cached preference it controls."""
+        if collection_name == "sleep":
+            return "sleep"
+        if collection_name == "feed":
+            mode = entry.get("mode")
+            if mode == "breast":
+                return "nursing"
+            if mode == "bottle":
+                return "bottle"
+            if mode == "solids":
+                return "solids"
+            raise HuckleberryRecordReferenceError("Referenced feed record has an unsupported mode")
+        if collection_name == "diaper":
+            return "potty" if entry.get("isPotty") is True else "diaper"
+        if entry.get("mode") == "growth":
+            return "growth"
+        raise HuckleberryRecordReferenceError("Referenced health record is not a growth entry")
+
+    def _candidate_matches_preference(
+        self,
+        collection_name: HistoryCollection,
+        preference_kind: HistoryPreferenceKind,
+        entry: RawHistoryData,
+    ) -> bool:
+        try:
+            return self._history_preference_kind(collection_name, entry) == preference_kind
+        except HuckleberryRecordReferenceError:
+            return False
+
+    async def _find_latest_history_candidate(
+        self,
+        *,
+        collection_name: HistoryCollection,
+        child_uid: str,
+        preference_kind: HistoryPreferenceKind,
+        transaction,
+        target_reference: FirebaseHistoryRecordReference,
+        replacement: RawHistoryData | None,
+    ) -> HistoryCandidate | None:
+        """Find the latest matching entry while logically applying one pending mutation."""
+        client = await self._get_firestore_client()
+        subcollection = (
+            client.collection(collection_name).document(child_uid).collection(_HISTORY_SUBCOLLECTION[collection_name])
+        )
+        latest: HistoryCandidate | None = None
+
+        def consider(entry: RawHistoryData, document_id: str, entry_key: str | None) -> None:
+            nonlocal latest
+            if not self._candidate_matches_preference(collection_name, preference_kind, entry):
+                return
+            start = entry.get("start")
+            if not isinstance(start, int | float):
+                return
+            if latest is None:
+                latest = (deepcopy(entry), document_id, entry_key)
+                return
+            latest_start = latest[0].get("start")
+            if not isinstance(latest_start, int | float) or float(start) > float(latest_start):
+                latest = (deepcopy(entry), document_id, entry_key)
+
+        if replacement is not None:
+            consider(replacement, target_reference.document_id, target_reference.entry_key)
+
+        regular_docs = subcollection.order_by("start", direction=firestore.Query.DESCENDING).stream(
+            transaction=transaction
+        )
+        async for doc in regular_docs:
+            if doc.id == target_reference.document_id and target_reference.entry_key is None:
+                continue
+            data = doc.to_dict()
+            if not data or data.get("multi") is True:
+                continue
+            if self._candidate_matches_preference(collection_name, preference_kind, data):
+                consider(data, doc.id, None)
+                break
+
+        multi_docs = subcollection.where(filter=firestore.FieldFilter("multi", "==", True)).stream(
+            transaction=transaction
+        )
+        async for doc in multi_docs:
+            data = doc.to_dict()
+            entries = data.get("data") if data else None
+            if not isinstance(entries, dict):
+                continue
+            for entry_key, entry in entries.items():
+                if (
+                    doc.id == target_reference.document_id
+                    and target_reference.entry_key is not None
+                    and entry_key == target_reference.entry_key
+                ):
+                    continue
+                if isinstance(entry, dict):
+                    consider(entry, doc.id, entry_key)
+
+        return latest
+
+    @staticmethod
+    def _history_preference_updates(
+        preference_kind: HistoryPreferenceKind,
+        latest: HistoryCandidate | None,
+        now: float,
+    ) -> dict[str, object]:
+        """Build the root-document cache update for one history category."""
+        updates: dict[str, object] = {
+            "prefs.timestamp": {"seconds": now},
+            "prefs.local_timestamp": now,
+        }
+        if latest is None:
+            field_by_kind = {
+                "sleep": "prefs.lastSleep",
+                "nursing": "prefs.lastNursing",
+                "bottle": "prefs.lastBottle",
+                "solids": "prefs.lastSolid",
+                "diaper": "prefs.lastDiaper",
+                "potty": "prefs.lastPotty",
+                "growth": "prefs.lastGrowthEntry",
+            }
+            updates[field_by_kind[preference_kind]] = DELETE_FIELD
+            if preference_kind == "nursing":
+                updates["prefs.lastSide"] = DELETE_FIELD
+            return updates
+
+        entry, document_id, entry_key = latest
+        if preference_kind == "sleep":
+            interval = FirebaseSleepIntervalData.model_validate(entry)
+            updates["prefs.lastSleep"] = to_firebase_dict(
+                FirebaseLastSleepData(start=interval.start, duration=interval.duration, offset=interval.offset)
+            )
+        elif preference_kind == "nursing":
+            interval = FirebaseBreastFeedIntervalData.model_validate(entry)
+            left_duration = interval.leftDuration or 0.0
+            right_duration = interval.rightDuration or 0.0
+            updates["prefs.lastNursing"] = to_firebase_dict(
+                FirebaseLastNursingData(
+                    mode="breast",
+                    start=interval.start,
+                    duration=float(left_duration) + float(right_duration),
+                    leftDuration=left_duration,
+                    rightDuration=right_duration,
+                    offset=interval.offset,
+                )
+            )
+            updates["prefs.lastSide"] = to_firebase_dict(
+                FirebaseLastSideData(start=interval.start, lastSide=interval.lastSide)
+            )
+        elif preference_kind == "bottle":
+            interval = FirebaseBottleFeedIntervalData.model_validate(entry)
+            updates["prefs.lastBottle"] = to_firebase_dict(
+                FirebaseLastBottleData(
+                    mode="bottle",
+                    start=interval.start,
+                    bottleType=interval.bottleType,
+                    bottleAmount=interval.amount,
+                    bottleUnits=interval.units,
+                    offset=interval.offset,
+                )
+            )
+        elif preference_kind == "solids":
+            interval = FirebaseSolidsFeedIntervalData.model_validate(entry)
+            updates["prefs.lastSolid"] = to_firebase_dict(
+                FirebaseLastSolidData(
+                    mode="solids",
+                    start=interval.start,
+                    foods=interval.foods,
+                    reactions=interval.reactions,
+                    notes=interval.notes,
+                    offset=interval.offset,
+                )
+            )
+        elif preference_kind == "diaper":
+            interval = FirebaseDiaperData.model_validate(entry)
+            updates["prefs.lastDiaper"] = to_firebase_dict(
+                FirebaseLastDiaperData(start=interval.start, mode=interval.mode, offset=interval.offset)
+            )
+        elif preference_kind == "potty":
+            interval = FirebaseDiaperData.model_validate(entry)
+            updates["prefs.lastPotty"] = to_firebase_dict(
+                FirebaseLastPottyData(start=interval.start, mode=interval.mode, offset=interval.offset)
+            )
+        else:
+            interval = FirebaseGrowthData.model_validate(entry)
+            growth_data = interval.model_dump(by_alias=True, exclude_none=True)
+            growth_data["_id"] = interval.id_ or entry_key or document_id
+            updates["prefs.lastGrowthEntry"] = growth_data
+        return updates
+
+    async def _mutate_history_record(
+        self,
+        *,
+        collection_name: HistoryCollection,
+        child_uid: str,
+        reference: FirebaseHistoryRecordReference,
+        allowed_preference_kinds: tuple[HistoryPreferenceKind, ...],
+        mutator: HistoryMutator,
+    ) -> None:
+        """Atomically mutate one exact entry and repair its cached latest value."""
+        client = await self._get_firestore_client()
+        root_ref = client.collection(collection_name).document(child_uid)
+        target_ref = root_ref.collection(_HISTORY_SUBCOLLECTION[collection_name]).document(reference.document_id)
+        transaction = client.transaction()
+
+        @firestore.async_transactional
+        async def apply_mutation(transaction) -> None:
+            doc = await target_ref.get(transaction=transaction)
+            if not doc.exists:
+                raise HuckleberryRecordNotFoundError("Referenced history document no longer exists")
+            self._validate_history_revision(doc, reference)
+            document_data = doc.to_dict()
+            if not document_data:
+                raise HuckleberryRecordNotFoundError("Referenced history document is empty")
+
+            original = self._extract_history_entry(document_data, reference)
+            preference_kind = self._history_preference_kind(collection_name, original)
+            if preference_kind not in allowed_preference_kinds:
+                raise HuckleberryRecordReferenceError("Referenced history record has the wrong type")
+
+            now = time.time()
+            replacement = mutator(deepcopy(original), now)
+            if replacement is not None:
+                replacement_kind = self._history_preference_kind(collection_name, replacement)
+                if replacement_kind != preference_kind:
+                    raise HuckleberryRecordReferenceError("A history mutation cannot change the record type")
+
+            latest = await self._find_latest_history_candidate(
+                collection_name=collection_name,
+                child_uid=child_uid,
+                preference_kind=preference_kind,
+                transaction=transaction,
+                target_reference=reference,
+                replacement=replacement,
+            )
+
+            updated_document = deepcopy(document_data)
+            if reference.entry_key is None:
+                if replacement is None:
+                    transaction.delete(target_ref)
+                else:
+                    transaction.set(target_ref, replacement)
+            else:
+                entries = updated_document.get("data")
+                if not isinstance(entries, dict):
+                    raise HuckleberryRecordReferenceError("Multi-entry history document has no data map")
+                if replacement is None:
+                    entries.pop(reference.entry_key, None)
+                else:
+                    entries[reference.entry_key] = replacement
+                if entries:
+                    updated_document["data"] = entries
+                    updated_document["lastUpdated"] = now
+                    transaction.set(target_ref, updated_document)
+                else:
+                    transaction.delete(target_ref)
+
+            transaction.update(root_ref, self._history_preference_updates(preference_kind, latest, now))
+
+        await apply_mutation(transaction)
+
+    @staticmethod
+    def _require_aware_datetime(value: datetime, field_name: str) -> float:
+        """Convert an aware datetime to seconds, rejecting host-local ambiguity."""
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError(f"{field_name} must include a timezone")
+        return value.timestamp()
+
+    async def update_sleep_interval(
+        self,
+        child_uid: str,
+        reference: FirebaseHistoryRecordReference,
+        *,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> None:
+        """Replace the timestamps of one sleep record if its revision still matches."""
+        start = self._require_aware_datetime(start_time, "start_time")
+        end = self._require_aware_datetime(end_time, "end_time")
+        if end <= start:
+            raise ValueError("end_time must be after start_time")
+
+        def mutate(entry: RawHistoryData, now: float) -> RawHistoryData:
+            FirebaseSleepIntervalData.model_validate(entry)
+            entry.update(
+                {
+                    "start": start,
+                    "duration": end - start,
+                    "offset": self._get_timezone_offset_minutes_at(start),
+                    "end_offset": self._get_timezone_offset_minutes_at(end),
+                    "lastUpdated": now,
+                }
+            )
+            FirebaseSleepIntervalData.model_validate(entry)
+            return entry
+
+        await self._mutate_history_record(
+            collection_name="sleep",
+            child_uid=child_uid,
+            reference=reference,
+            allowed_preference_kinds=("sleep",),
+            mutator=mutate,
+        )
+
+    async def delete_sleep_interval(
+        self,
+        child_uid: str,
+        reference: FirebaseHistoryRecordReference,
+    ) -> None:
+        """Delete one sleep record if its revision still matches."""
+        await self._mutate_history_record(
+            collection_name="sleep",
+            child_uid=child_uid,
+            reference=reference,
+            allowed_preference_kinds=("sleep",),
+            mutator=lambda _entry, _now: None,
+        )
+
+    async def update_nursing_interval(
+        self,
+        child_uid: str,
+        reference: FirebaseHistoryRecordReference,
+        *,
+        start_time: datetime,
+        left_duration: float,
+        right_duration: float,
+        last_side: Literal["left", "right"],
+    ) -> None:
+        """Replace one nursing record if its revision still matches."""
+        start = self._require_aware_datetime(start_time, "start_time")
+        if left_duration < 0 or right_duration < 0 or left_duration + right_duration <= 0:
+            raise ValueError("Nursing durations must be non-negative with a positive total")
+
+        def mutate(entry: RawHistoryData, now: float) -> RawHistoryData:
+            FirebaseBreastFeedIntervalData.model_validate(entry)
+            end = start + left_duration + right_duration
+            entry.update(
+                {
+                    "start": start,
+                    "leftDuration": left_duration,
+                    "rightDuration": right_duration,
+                    "lastSide": last_side,
+                    "offset": self._get_timezone_offset_minutes_at(start),
+                    "end_offset": self._get_timezone_offset_minutes_at(end),
+                    "lastUpdated": now,
+                }
+            )
+            FirebaseBreastFeedIntervalData.model_validate(entry)
+            return entry
+
+        await self._mutate_history_record(
+            collection_name="feed",
+            child_uid=child_uid,
+            reference=reference,
+            allowed_preference_kinds=("nursing",),
+            mutator=mutate,
+        )
+
+    async def update_bottle_interval(
+        self,
+        child_uid: str,
+        reference: FirebaseHistoryRecordReference,
+        *,
+        start_time: datetime,
+        amount: float,
+        bottle_type: BottleType,
+        units: VolumeUnits,
+    ) -> None:
+        """Replace one bottle record if its revision still matches."""
+        start = self._require_aware_datetime(start_time, "start_time")
+        if amount <= 0:
+            raise ValueError("amount must be positive")
+
+        def mutate(entry: RawHistoryData, now: float) -> RawHistoryData:
+            FirebaseBottleFeedIntervalData.model_validate(entry)
+            entry.update(
+                {
+                    "start": start,
+                    "amount": amount,
+                    "bottleType": bottle_type,
+                    "units": units,
+                    "offset": self._get_timezone_offset_minutes_at(start),
+                    "end_offset": self._get_timezone_offset_minutes_at(start),
+                    "lastUpdated": now,
+                }
+            )
+            FirebaseBottleFeedIntervalData.model_validate(entry)
+            return entry
+
+        await self._mutate_history_record(
+            collection_name="feed",
+            child_uid=child_uid,
+            reference=reference,
+            allowed_preference_kinds=("bottle",),
+            mutator=mutate,
+        )
+
+    async def delete_feed_interval(
+        self,
+        child_uid: str,
+        reference: FirebaseHistoryRecordReference,
+    ) -> None:
+        """Delete one nursing, bottle, or solids record if its revision still matches."""
+        await self._mutate_history_record(
+            collection_name="feed",
+            child_uid=child_uid,
+            reference=reference,
+            allowed_preference_kinds=("nursing", "bottle", "solids"),
+            mutator=lambda _entry, _now: None,
+        )
+
+    async def update_diaper_interval(
+        self,
+        child_uid: str,
+        reference: FirebaseHistoryRecordReference,
+        *,
+        start_time: datetime,
+        mode: DiaperMode,
+        pee_amount: Literal["little", "medium", "big"] | None = None,
+        poo_amount: Literal["little", "medium", "big"] | None = None,
+        color: PooColor | None = None,
+        consistency: PooConsistency | None = None,
+        diaper_rash: bool = False,
+        notes: str | None = None,
+    ) -> None:
+        """Replace one diaper record if its revision still matches."""
+        start = self._require_aware_datetime(start_time, "start_time")
+        amount_map = {"little": 0.0, "medium": 50.0, "big": 100.0}
+
+        def mutate(entry: RawHistoryData, now: float) -> RawHistoryData:
+            FirebaseDiaperData.model_validate(entry)
+            quantity: dict[str, float] = {}
+            if pee_amount is not None:
+                quantity["pee"] = amount_map[pee_amount]
+            if poo_amount is not None:
+                quantity["poo"] = amount_map[poo_amount]
+            entry.update(
+                {
+                    "start": start,
+                    "mode": mode,
+                    "offset": self._get_timezone_offset_minutes_at(start),
+                    "lastUpdated": now,
+                }
+            )
+            optional_values: dict[str, object | None] = {
+                "quantity": quantity or None,
+                "color": color,
+                "consistency": consistency,
+                "diaperRash": True if diaper_rash else None,
+                "notes": notes,
+            }
+            for field_name, value in optional_values.items():
+                if value is None:
+                    entry.pop(field_name, None)
+                else:
+                    entry[field_name] = value
+            FirebaseDiaperData.model_validate(entry)
+            return entry
+
+        await self._mutate_history_record(
+            collection_name="diaper",
+            child_uid=child_uid,
+            reference=reference,
+            allowed_preference_kinds=("diaper",),
+            mutator=mutate,
+        )
+
+    async def delete_diaper_interval(
+        self,
+        child_uid: str,
+        reference: FirebaseHistoryRecordReference,
+    ) -> None:
+        """Delete one diaper or potty record if its revision still matches."""
+        await self._mutate_history_record(
+            collection_name="diaper",
+            child_uid=child_uid,
+            reference=reference,
+            allowed_preference_kinds=("diaper", "potty"),
+            mutator=lambda _entry, _now: None,
+        )
+
+    async def update_growth_entry(
+        self,
+        child_uid: str,
+        reference: FirebaseHistoryRecordReference,
+        *,
+        start_time: datetime,
+        weight: float | None = None,
+        height: float | None = None,
+        head: float | None = None,
+        units: Literal["metric", "imperial"] = "metric",
+    ) -> None:
+        """Replace one growth record if its revision still matches."""
+        start = self._require_aware_datetime(start_time, "start_time")
+        measurements = [value for value in (weight, height, head) if value is not None]
+        if not measurements or any(value <= 0 for value in measurements):
+            raise ValueError("At least one positive growth measurement is required")
+
+        def mutate(entry: RawHistoryData, now: float) -> RawHistoryData:
+            FirebaseGrowthData.model_validate(entry)
+            for field_name in ("weight", "weightUnits", "height", "heightUnits", "head", "headUnits"):
+                entry.pop(field_name, None)
+            entry.update(
+                {
+                    "start": start,
+                    "offset": self._get_timezone_offset_minutes_at(start),
+                    "lastUpdated": now,
+                }
+            )
+            if weight is not None:
+                entry["weight"] = weight
+                entry["weightUnits"] = "kg" if units == "metric" else "lbs.oz"
+            if height is not None:
+                entry["height"] = height
+                entry["heightUnits"] = "cm" if units == "metric" else "ft.in"
+            if head is not None:
+                entry["head"] = head
+                entry["headUnits"] = "hcm" if units == "metric" else "hin"
+            FirebaseGrowthData.model_validate(entry)
+            return entry
+
+        await self._mutate_history_record(
+            collection_name="health",
+            child_uid=child_uid,
+            reference=reference,
+            allowed_preference_kinds=("growth",),
+            mutator=mutate,
+        )
+
+    async def delete_growth_entry(
+        self,
+        child_uid: str,
+        reference: FirebaseHistoryRecordReference,
+    ) -> None:
+        """Delete one growth record if its revision still matches."""
+        await self._mutate_history_record(
+            collection_name="health",
+            child_uid=child_uid,
+            reference=reference,
+            allowed_preference_kinds=("growth",),
+            mutator=lambda _entry, _now: None,
+        )
+
+    async def list_sleep_interval_records(
         self,
         child_uid: str,
         start_time: datetime,
         end_time: datetime,
-    ) -> list[FirebaseSleepIntervalData]:
+    ) -> list[FirebaseSleepIntervalRecord]:
         """
-        Fetch sleep intervals from Firestore for a date range.
+        Fetch sleep intervals with stable record references for a date range.
 
         Args:
             child_uid: Child unique identifier
@@ -2020,9 +2705,9 @@ class HuckleberryAPI:
             end_time: End of range
 
         Returns:
-            List of Firebase-validated sleep interval entries
+            List of validated sleep records with optimistic-concurrency references
         """
-        events: list[FirebaseSleepIntervalData] = []
+        records: list[FirebaseSleepIntervalRecord] = []
         start_timestamp, end_timestamp = start_time.timestamp(), end_time.timestamp()
         client = await self._get_firestore_client()
         sleep_ref = client.collection("sleep").document(child_uid)
@@ -2043,7 +2728,12 @@ class HuckleberryAPI:
                     continue  # Skip multi-entry docs from this query
 
                 interval = FirebaseSleepIntervalData.model_validate(data)
-                events.append(interval)
+                records.append(
+                    FirebaseSleepIntervalRecord(
+                        reference=self._history_record_reference(doc),
+                        data=interval,
+                    )
+                )
 
             # Query 2: Get multi-entry documents (can't filter by nested start field)
             multi_docs = intervals_ref.where(filter=firestore.FieldFilter("multi", "==", True)).stream()
@@ -2056,26 +2746,41 @@ class HuckleberryAPI:
                 container = FirebaseSleepMultiContainer.model_validate(data)
 
                 # Iterate through batched entries and filter by date
-                for entry in container.data.values():
+                for entry_key, entry in container.data.items():
                     entry_start = entry.start
                     if not (start_timestamp <= entry_start < end_timestamp):
                         continue
 
-                    events.append(entry)
+                    records.append(
+                        FirebaseSleepIntervalRecord(
+                            reference=self._history_record_reference(doc, entry_key),
+                            data=entry,
+                        )
+                    )
 
         except (GoogleAPICallError, ValidationError) as err:
             _LOGGER.error("Error fetching sleep intervals: %s", err)
 
-        return events
+        return records
 
-    async def list_feed_intervals(
+    async def list_sleep_intervals(
         self,
         child_uid: str,
         start_time: datetime,
         end_time: datetime,
-    ) -> list[FirebaseFeedIntervalData]:
+    ) -> list[FirebaseSleepIntervalData]:
+        """Fetch sleep interval payloads for a date range."""
+        records = await self.list_sleep_interval_records(child_uid, start_time, end_time)
+        return [record.data for record in records]
+
+    async def list_feed_interval_records(
+        self,
+        child_uid: str,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> list[FirebaseFeedIntervalRecord]:
         """
-        Fetch feeding intervals from Firestore for a date range.
+        Fetch feeding intervals with stable record references for a date range.
 
         Args:
             child_uid: Child unique identifier
@@ -2083,9 +2788,9 @@ class HuckleberryAPI:
             end_time: End of range
 
         Returns:
-            List of Firebase-validated feed interval entries
+            List of validated feed records with optimistic-concurrency references
         """
-        events: list[FirebaseFeedIntervalData] = []
+        records: list[FirebaseFeedIntervalRecord] = []
         start_timestamp, end_timestamp = start_time.timestamp(), end_time.timestamp()
         client = await self._get_firestore_client()
         feed_ref = client.collection("feed").document(child_uid)
@@ -2110,7 +2815,12 @@ class HuckleberryAPI:
                 if feed_mode is None:
                     continue
 
-                events.append(interval)
+                records.append(
+                    FirebaseFeedIntervalRecord(
+                        reference=self._history_record_reference(doc),
+                        data=interval,
+                    )
+                )
 
             # Query 2: Get multi-entry documents (can't filter by nested start field)
             multi_docs = intervals_ref.where(filter=firestore.FieldFilter("multi", "==", True)).stream()
@@ -2123,7 +2833,7 @@ class HuckleberryAPI:
                 container = FirebaseFeedMultiContainer.model_validate(data)
 
                 # Iterate through batched entries and filter by date
-                for entry in container.data.values():
+                for entry_key, entry in container.data.items():
                     entry_start = entry.start
                     if not (start_timestamp <= entry_start < end_timestamp):
                         continue
@@ -2132,21 +2842,36 @@ class HuckleberryAPI:
                     if feed_mode is None:
                         continue
 
-                    events.append(entry)
+                    records.append(
+                        FirebaseFeedIntervalRecord(
+                            reference=self._history_record_reference(doc, entry_key),
+                            data=entry,
+                        )
+                    )
 
         except (GoogleAPICallError, ValidationError) as err:
             _LOGGER.error("Error fetching feed intervals: %s", err)
 
-        return events
+        return records
 
-    async def list_diaper_intervals(
+    async def list_feed_intervals(
         self,
         child_uid: str,
         start_time: datetime,
         end_time: datetime,
-    ) -> list[FirebaseDiaperData]:
+    ) -> list[FirebaseFeedIntervalData]:
+        """Fetch feed interval payloads for a date range."""
+        records = await self.list_feed_interval_records(child_uid, start_time, end_time)
+        return [record.data for record in records]
+
+    async def list_diaper_interval_records(
+        self,
+        child_uid: str,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> list[FirebaseDiaperIntervalRecord]:
         """
-        Fetch diaper intervals from Firestore for a date range.
+        Fetch diaper intervals with stable record references for a date range.
 
         Args:
             child_uid: Child unique identifier
@@ -2154,9 +2879,9 @@ class HuckleberryAPI:
             end_time: End of range
 
         Returns:
-            List of Firebase-validated diaper interval entries
+            List of validated diaper records with optimistic-concurrency references
         """
-        events: list[FirebaseDiaperData] = []
+        records: list[FirebaseDiaperIntervalRecord] = []
         start_timestamp, end_timestamp = start_time.timestamp(), end_time.timestamp()
         client = await self._get_firestore_client()
         diaper_ref = client.collection("diaper").document(child_uid)
@@ -2177,7 +2902,12 @@ class HuckleberryAPI:
                     continue  # Skip multi-entry docs from this query
 
                 entry = FirebaseDiaperData.model_validate(data)
-                events.append(entry)
+                records.append(
+                    FirebaseDiaperIntervalRecord(
+                        reference=self._history_record_reference(doc),
+                        data=entry,
+                    )
+                )
 
             # Query 2: Get multi-entry documents (can't filter by nested start field)
             multi_docs = intervals_ref.where(filter=firestore.FieldFilter("multi", "==", True)).stream()
@@ -2190,26 +2920,41 @@ class HuckleberryAPI:
                 container = FirebaseDiaperMultiContainer.model_validate(data)
 
                 # Iterate through batched entries and filter by date
-                for entry in container.data.values():
+                for entry_key, entry in container.data.items():
                     entry_start = entry.start
                     if not (start_timestamp <= entry_start < end_timestamp):
                         continue
 
-                    events.append(entry)
+                    records.append(
+                        FirebaseDiaperIntervalRecord(
+                            reference=self._history_record_reference(doc, entry_key),
+                            data=entry,
+                        )
+                    )
 
         except (GoogleAPICallError, ValidationError) as err:
             _LOGGER.error("Error fetching diaper intervals: %s", err)
 
-        return events
+        return records
 
-    async def list_health_entries(
+    async def list_diaper_intervals(
         self,
         child_uid: str,
         start_time: datetime,
         end_time: datetime,
-    ) -> list[HealthDataEntry]:
+    ) -> list[FirebaseDiaperData]:
+        """Fetch diaper interval payloads for a date range."""
+        records = await self.list_diaper_interval_records(child_uid, start_time, end_time)
+        return [record.data for record in records]
+
+    async def list_health_entry_records(
+        self,
+        child_uid: str,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> list[FirebaseHealthEntryRecord]:
         """
-        Fetch health entries from Firestore for a date range.
+        Fetch health entries with stable record references for a date range.
 
         Args:
             child_uid: Child unique identifier
@@ -2217,9 +2962,9 @@ class HuckleberryAPI:
             end_time: End of range
 
         Returns:
-            List of Firebase-validated health entries
+            List of validated health records with optimistic-concurrency references
         """
-        events: list[HealthDataEntry] = []
+        records: list[FirebaseHealthEntryRecord] = []
         start_timestamp, end_timestamp = start_time.timestamp(), end_time.timestamp()
         client = await self._get_firestore_client()
         health_ref = client.collection("health").document(child_uid)
@@ -2241,7 +2986,12 @@ class HuckleberryAPI:
                     continue  # Skip multi-entry docs from this query
 
                 entry = _HEALTH_ENTRY_ADAPTER.validate_python(data)
-                events.append(entry)
+                records.append(
+                    FirebaseHealthEntryRecord(
+                        reference=self._history_record_reference(doc),
+                        data=entry,
+                    )
+                )
 
             # Query 2: Get multi-entry documents (can't filter by nested start field)
             multi_docs = data_ref.where(filter=firestore.FieldFilter("multi", "==", True)).stream()
@@ -2254,17 +3004,32 @@ class HuckleberryAPI:
                 container = FirebaseHealthMultiContainer.model_validate(data)
 
                 # Iterate through batched entries and filter by date
-                for entry in container.data.values():
+                for entry_key, entry in container.data.items():
                     entry_start = entry.start
                     if not (start_timestamp <= entry_start < end_timestamp):
                         continue
 
-                    events.append(entry)
+                    records.append(
+                        FirebaseHealthEntryRecord(
+                            reference=self._history_record_reference(doc, entry_key),
+                            data=entry,
+                        )
+                    )
 
         except (GoogleAPICallError, ValidationError) as err:
             _LOGGER.error("Error fetching health entries: %s", err)
 
-        return events
+        return records
+
+    async def list_health_entries(
+        self,
+        child_uid: str,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> list[HealthDataEntry]:
+        """Fetch health entry payloads for a date range."""
+        records = await self.list_health_entry_records(child_uid, start_time, end_time)
+        return [record.data for record in records]
 
     async def list_pump_intervals(
         self,

--- a/src/huckleberry_api/api.py
+++ b/src/huckleberry_api/api.py
@@ -15,7 +15,7 @@ from urllib.parse import quote
 from zoneinfo import ZoneInfo
 
 import aiohttp
-from google.api_core.exceptions import GoogleAPICallError
+from google.api_core.exceptions import FailedPrecondition, GoogleAPICallError
 from google.auth.credentials import Credentials
 from google.cloud import firestore
 from google.cloud.firestore import DELETE_FIELD
@@ -2346,67 +2346,85 @@ class HuckleberryAPI:
         allowed_preference_kinds: tuple[HistoryPreferenceKind, ...],
         mutator: HistoryMutator,
     ) -> None:
-        """Atomically mutate one exact entry and repair its cached latest value."""
+        """Atomically mutate one exact entry and repair its cached latest value.
+
+        The batch is conditional on both the history document revision returned
+        to the caller and the child root document revision used to rebuild the
+        cached latest value. Concurrent history writes therefore fail closed.
+        """
         client = await self._get_firestore_client()
         root_ref = client.collection(collection_name).document(child_uid)
         target_ref = root_ref.collection(_HISTORY_SUBCOLLECTION[collection_name]).document(reference.document_id)
-        transaction = client.transaction()
+        target_doc, root_doc = await asyncio.gather(target_ref.get(), root_ref.get())
+        if not target_doc.exists:
+            raise HuckleberryRecordNotFoundError("Referenced history document no longer exists")
+        if not root_doc.exists or root_doc.update_time is None:
+            raise HuckleberryRecordReferenceError("History root document is unavailable")
+        self._validate_history_revision(target_doc, reference)
+        document_data = target_doc.to_dict()
+        if not document_data:
+            raise HuckleberryRecordNotFoundError("Referenced history document is empty")
 
-        @firestore.async_transactional
-        async def apply_mutation(transaction) -> None:
-            doc = await target_ref.get(transaction=transaction)
-            if not doc.exists:
-                raise HuckleberryRecordNotFoundError("Referenced history document no longer exists")
-            self._validate_history_revision(doc, reference)
-            document_data = doc.to_dict()
-            if not document_data:
-                raise HuckleberryRecordNotFoundError("Referenced history document is empty")
+        original = self._extract_history_entry(document_data, reference)
+        preference_kind = self._history_preference_kind(collection_name, original)
+        if preference_kind not in allowed_preference_kinds:
+            raise HuckleberryRecordReferenceError("Referenced history record has the wrong type")
 
-            original = self._extract_history_entry(document_data, reference)
-            preference_kind = self._history_preference_kind(collection_name, original)
-            if preference_kind not in allowed_preference_kinds:
-                raise HuckleberryRecordReferenceError("Referenced history record has the wrong type")
+        now = time.time()
+        replacement = mutator(deepcopy(original), now)
+        if replacement is not None:
+            replacement_kind = self._history_preference_kind(collection_name, replacement)
+            if replacement_kind != preference_kind:
+                raise HuckleberryRecordReferenceError("A history mutation cannot change the record type")
 
-            now = time.time()
-            replacement = mutator(deepcopy(original), now)
-            if replacement is not None:
-                replacement_kind = self._history_preference_kind(collection_name, replacement)
-                if replacement_kind != preference_kind:
-                    raise HuckleberryRecordReferenceError("A history mutation cannot change the record type")
+        latest = await self._find_latest_history_candidate(
+            collection_name=collection_name,
+            child_uid=child_uid,
+            preference_kind=preference_kind,
+            transaction=None,
+            target_reference=reference,
+            replacement=replacement,
+        )
 
-            latest = await self._find_latest_history_candidate(
-                collection_name=collection_name,
-                child_uid=child_uid,
-                preference_kind=preference_kind,
-                transaction=transaction,
-                target_reference=reference,
-                replacement=replacement,
-            )
-
-            updated_document = deepcopy(document_data)
-            if reference.entry_key is None:
-                if replacement is None:
-                    transaction.delete(target_ref)
-                else:
-                    transaction.set(target_ref, replacement)
+        batch = client.batch()
+        target_option = client.write_option(last_update_time=target_doc.update_time)
+        root_option = client.write_option(last_update_time=root_doc.update_time)
+        updated_document = deepcopy(document_data)
+        if reference.entry_key is None:
+            if replacement is None:
+                batch.delete(target_ref, option=target_option)
             else:
-                entries = updated_document.get("data")
-                if not isinstance(entries, dict):
-                    raise HuckleberryRecordReferenceError("Multi-entry history document has no data map")
-                if replacement is None:
-                    entries.pop(reference.entry_key, None)
-                else:
-                    entries[reference.entry_key] = replacement
-                if entries:
-                    updated_document["data"] = entries
-                    updated_document["lastUpdated"] = now
-                    transaction.set(target_ref, updated_document)
-                else:
-                    transaction.delete(target_ref)
+                field_updates = {
+                    **{field_name: DELETE_FIELD for field_name in original.keys() - replacement.keys()},
+                    **replacement,
+                }
+                batch.update(target_ref, field_updates, option=target_option)
+        else:
+            entries = updated_document.get("data")
+            if not isinstance(entries, dict):
+                raise HuckleberryRecordReferenceError("Multi-entry history document has no data map")
+            if replacement is None:
+                entries.pop(reference.entry_key, None)
+            else:
+                entries[reference.entry_key] = replacement
+            if entries:
+                batch.update(
+                    target_ref,
+                    {"data": entries, "lastUpdated": now},
+                    option=target_option,
+                )
+            else:
+                batch.delete(target_ref, option=target_option)
 
-            transaction.update(root_ref, self._history_preference_updates(preference_kind, latest, now))
-
-        await apply_mutation(transaction)
+        batch.update(
+            root_ref,
+            self._history_preference_updates(preference_kind, latest, now),
+            option=root_option,
+        )
+        try:
+            await batch.commit()
+        except FailedPrecondition as exc:
+            raise HuckleberryRecordConflictError("History changed while applying the mutation; fetch it again") from exc
 
     @staticmethod
     def _require_aware_datetime(value: datetime, field_name: str) -> float:

--- a/src/huckleberry_api/exceptions.py
+++ b/src/huckleberry_api/exceptions.py
@@ -1,0 +1,19 @@
+"""Public exceptions raised by history record mutations."""
+
+from __future__ import annotations
+
+
+class HuckleberryRecordError(RuntimeError):
+    """Base class for safe history record mutation failures."""
+
+
+class HuckleberryRecordNotFoundError(HuckleberryRecordError):
+    """The referenced history record no longer exists."""
+
+
+class HuckleberryRecordConflictError(HuckleberryRecordError):
+    """The referenced history record changed after it was read."""
+
+
+class HuckleberryRecordReferenceError(HuckleberryRecordError):
+    """The supplied history record reference is malformed or mismatched."""

--- a/src/huckleberry_api/firebase_types.py
+++ b/src/huckleberry_api/firebase_types.py
@@ -34,6 +34,22 @@ class StrictModel(BaseModel):
     model_config = ConfigDict(extra="ignore", strict=True, populate_by_name=True, protected_namespaces=())
 
 
+class FirebaseHistoryRecordReference(StrictModel):
+    """Stable reference to one history entry.
+
+    ``document_id`` identifies the Firestore document. ``entry_key`` identifies
+    an entry inside a batched ``multi`` document and is ``None`` for a regular
+    history document. ``revision`` is the Firestore document update timestamp
+    captured by a list operation and is required for optimistic concurrency.
+
+    This is API metadata and is never written into Huckleberry documents.
+    """
+
+    document_id: str = Field(min_length=1, pattern=r"^[^/]+$")
+    entry_key: str | None = Field(default=None, min_length=1)
+    revision: str = Field(min_length=1)
+
+
 DiaperMode = Literal["pee", "poo", "both", "dry"]
 PooColor = Literal["yellow", "brown", "black", "green", "red", "gray"]
 PooConsistency = Literal["solid", "loose", "runny", "mucousy", "hard", "pebbles", "diarrhea"]
@@ -403,6 +419,13 @@ class FirebaseSleepMultiContainer(StrictModel):
     data: dict[str, FirebaseSleepIntervalData]
 
 
+class FirebaseSleepIntervalRecord(StrictModel):
+    """Sleep history entry paired with its stable mutation reference."""
+
+    reference: FirebaseHistoryRecordReference
+    data: FirebaseSleepIntervalData
+
+
 # ---------------------------------------------------------------------------
 # feed/{child_uid}
 # ---------------------------------------------------------------------------
@@ -604,6 +627,13 @@ class FirebaseFeedMultiContainer(StrictModel):
     data: dict[str, FirebaseFeedIntervalData]
 
 
+class FirebaseFeedIntervalRecord(StrictModel):
+    """Feed history entry paired with its stable mutation reference."""
+
+    reference: FirebaseHistoryRecordReference
+    data: FirebaseFeedIntervalData
+
+
 # ---------------------------------------------------------------------------
 # diaper/{child_uid}
 # ---------------------------------------------------------------------------
@@ -674,6 +704,13 @@ class FirebaseDiaperMultiContainer(StrictModel):
     hasMoreRoom: bool | None = None
     lastUpdated: Number | None = None
     data: dict[str, FirebaseDiaperData]
+
+
+class FirebaseDiaperIntervalRecord(StrictModel):
+    """Diaper history entry paired with its stable mutation reference."""
+
+    reference: FirebaseHistoryRecordReference
+    data: FirebaseDiaperData
 
 
 # ---------------------------------------------------------------------------
@@ -765,6 +802,13 @@ class FirebaseHealthMultiContainer(StrictModel):
     hasMoreRoom: bool | None = None
     lastUpdated: Number | None = None
     data: dict[str, HealthDataEntry]
+
+
+class FirebaseHealthEntryRecord(StrictModel):
+    """Health history entry paired with its stable mutation reference."""
+
+    reference: FirebaseHistoryRecordReference
+    data: HealthDataEntry
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_history_mutations.py
+++ b/tests/test_history_mutations.py
@@ -1,0 +1,473 @@
+"""Unit tests for revision-safe history record mutations."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import cast
+
+import aiohttp
+import pytest
+from google.cloud import firestore
+from google.cloud.firestore_v1.base_query import FieldFilter
+
+from huckleberry_api import HuckleberryAPI, HuckleberryRecordConflictError
+from huckleberry_api.firebase_types import FirebaseHistoryRecordReference
+
+
+class FakeSnapshot:
+    """Small Firestore snapshot used by history mutation tests."""
+
+    def __init__(self, document_id: str, data: dict[str, object], revision: datetime):
+        self.id = document_id
+        self._data = deepcopy(data)
+        self.update_time = revision
+        self.exists = True
+
+    def to_dict(self) -> dict[str, object]:
+        return deepcopy(self._data)
+
+
+class FakeDocumentReference:
+    def __init__(self, client: FakeClient, path: tuple[str, ...]):
+        self.client = client
+        self.path = path
+
+    def collection(self, name: str) -> FakeCollectionReference:
+        return FakeCollectionReference(self.client, (*self.path, name))
+
+    async def get(self, transaction=None) -> FakeSnapshot:
+        del transaction
+        return self.client.documents[self.path]
+
+
+class FakeQuery:
+    def __init__(
+        self,
+        client: FakeClient,
+        path: tuple[str, ...],
+        filters: list[FieldFilter] | None = None,
+        order_field: str | None = None,
+        descending: bool = False,
+    ):
+        self.client = client
+        self.path = path
+        self.filters = filters or []
+        self.order_field = order_field
+        self.descending = descending
+
+    def where(self, *, filter) -> FakeQuery:
+        return FakeQuery(
+            self.client,
+            self.path,
+            [*self.filters, filter],
+            self.order_field,
+            self.descending,
+        )
+
+    def order_by(self, field: str, direction=None) -> FakeQuery:
+        return FakeQuery(
+            self.client,
+            self.path,
+            self.filters,
+            field,
+            direction == firestore.Query.DESCENDING,
+        )
+
+    async def stream(self, transaction=None):
+        del transaction
+        snapshots = [snapshot for path, snapshot in self.client.documents.items() if path[:-1] == self.path]
+        for field_filter in self.filters:
+            filtered: list[FakeSnapshot] = []
+            for snapshot in snapshots:
+                value = snapshot.to_dict().get(field_filter.field_path)
+                if field_filter.op_string == "==":
+                    matches = value == field_filter.value
+                elif field_filter.op_string == ">=":
+                    matches = (
+                        isinstance(value, int | float)
+                        and isinstance(field_filter.value, int | float)
+                        and value >= field_filter.value
+                    )
+                elif field_filter.op_string == "<":
+                    matches = (
+                        isinstance(value, int | float)
+                        and isinstance(field_filter.value, int | float)
+                        and value < field_filter.value
+                    )
+                else:
+                    raise AssertionError(f"Unsupported fake filter: {field_filter.op_string}")
+                if matches:
+                    filtered.append(snapshot)
+            snapshots = filtered
+        if self.order_field is not None:
+            snapshots = [snapshot for snapshot in snapshots if snapshot.to_dict().get(self.order_field) is not None]
+            snapshots.sort(
+                key=lambda snapshot: snapshot.to_dict()[cast(str, self.order_field)],
+                reverse=self.descending,
+            )
+        for snapshot in snapshots:
+            yield snapshot
+
+
+class FakeCollectionReference(FakeQuery):
+    def document(self, document_id: str) -> FakeDocumentReference:
+        return FakeDocumentReference(self.client, (*self.path, document_id))
+
+
+class FakeTransaction:
+    def __init__(self):
+        self.operations: list[tuple[str, tuple[str, ...], dict[str, object] | None]] = []
+
+    def set(self, reference: FakeDocumentReference, data: dict[str, object]) -> None:
+        self.operations.append(("set", reference.path, deepcopy(data)))
+
+    def update(self, reference: FakeDocumentReference, data: dict[str, object]) -> None:
+        self.operations.append(("update", reference.path, deepcopy(data)))
+
+    def delete(self, reference: FakeDocumentReference) -> None:
+        self.operations.append(("delete", reference.path, None))
+
+
+class FakeClient:
+    def __init__(self, documents: dict[tuple[str, ...], FakeSnapshot]):
+        self.documents = documents
+        self.last_transaction: FakeTransaction | None = None
+
+    def collection(self, name: str) -> FakeCollectionReference:
+        return FakeCollectionReference(self, (name,))
+
+    def transaction(self) -> FakeTransaction:
+        self.last_transaction = FakeTransaction()
+        return self.last_transaction
+
+
+def make_api(monkeypatch: pytest.MonkeyPatch, client: FakeClient) -> HuckleberryAPI:
+    """Create an API instance backed by the in-memory fake Firestore client."""
+    api = HuckleberryAPI(
+        email="test@example.com",
+        password="not-a-real-password",
+        timezone="America/New_York",
+        websession=cast(aiohttp.ClientSession, object()),
+    )
+
+    async def get_client() -> FakeClient:
+        return client
+
+    monkeypatch.setattr(api, "_get_firestore_client", get_client)
+    monkeypatch.setattr(firestore, "async_transactional", lambda function: function)
+    return api
+
+
+def revision(value: datetime) -> str:
+    return value.isoformat()
+
+
+async def test_list_sleep_records_include_regular_and_multi_references(monkeypatch: pytest.MonkeyPatch) -> None:
+    regular_revision = datetime(2026, 8, 18, 12, 0, tzinfo=timezone.utc)
+    multi_revision = datetime(2026, 8, 18, 12, 1, tzinfo=timezone.utc)
+    documents = {
+        ("sleep", "child", "intervals", "regular-id"): FakeSnapshot(
+            "regular-id",
+            {"start": 100.0, "duration": 60.0, "offset": 240.0},
+            regular_revision,
+        ),
+        ("sleep", "child", "intervals", "multi-id"): FakeSnapshot(
+            "multi-id",
+            {
+                "multi": True,
+                "data": {"entry-key": {"start": 200.0, "duration": 120.0, "offset": 240.0}},
+            },
+            multi_revision,
+        ),
+    }
+    api = make_api(monkeypatch, FakeClient(documents))
+
+    records = await api.list_sleep_interval_records(
+        "child",
+        datetime.fromtimestamp(0, timezone.utc),
+        datetime.fromtimestamp(1000, timezone.utc),
+    )
+
+    references = {record.reference.document_id: record.reference for record in records}
+    assert references["regular-id"].entry_key is None
+    assert references["regular-id"].revision == revision(regular_revision)
+    assert references["multi-id"].entry_key == "entry-key"
+    assert references["multi-id"].revision == revision(multi_revision)
+
+
+async def test_stale_reference_is_rejected_before_writes(monkeypatch: pytest.MonkeyPatch) -> None:
+    current_revision = datetime(2026, 8, 18, 12, 0, tzinfo=timezone.utc)
+    client = FakeClient(
+        {
+            ("sleep", "child", "intervals", "sleep-id"): FakeSnapshot(
+                "sleep-id",
+                {"start": 100.0, "duration": 60.0, "offset": 240.0},
+                current_revision,
+            )
+        }
+    )
+    api = make_api(monkeypatch, client)
+    stale_reference = FirebaseHistoryRecordReference(
+        document_id="sleep-id",
+        revision=revision(datetime(2026, 8, 18, 11, 59, tzinfo=timezone.utc)),
+    )
+
+    with pytest.raises(HuckleberryRecordConflictError):
+        await api.delete_sleep_interval("child", stale_reference)
+
+    assert client.last_transaction is not None
+    assert client.last_transaction.operations == []
+
+
+async def test_delete_repairs_last_sleep_in_same_transaction(monkeypatch: pytest.MonkeyPatch) -> None:
+    target_revision = datetime(2026, 8, 18, 12, 0, tzinfo=timezone.utc)
+    documents = {
+        ("sleep", "child", "intervals", "latest-id"): FakeSnapshot(
+            "latest-id",
+            {"start": 200.0, "duration": 60.0, "offset": 240.0},
+            target_revision,
+        ),
+        ("sleep", "child", "intervals", "previous-id"): FakeSnapshot(
+            "previous-id",
+            {"start": 100.0, "duration": 30.0, "offset": 240.0},
+            datetime(2026, 8, 18, 11, 0, tzinfo=timezone.utc),
+        ),
+    }
+    client = FakeClient(documents)
+    api = make_api(monkeypatch, client)
+    reference = FirebaseHistoryRecordReference(
+        document_id="latest-id",
+        revision=revision(target_revision),
+    )
+
+    await api.delete_sleep_interval("child", reference)
+
+    assert client.last_transaction is not None
+    operations = client.last_transaction.operations
+    assert ("delete", ("sleep", "child", "intervals", "latest-id"), None) in operations
+    root_update = next(
+        data for operation, path, data in operations if operation == "update" and path == ("sleep", "child")
+    )
+    assert root_update is not None
+    assert root_update["prefs.lastSleep"] == {"start": 100.0, "duration": 30.0, "offset": 240.0}
+
+
+async def test_update_multi_bottle_preserves_container_and_repairs_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    target_revision = datetime(2026, 8, 18, 12, 0, tzinfo=timezone.utc)
+    documents = {
+        ("feed", "child", "intervals", "multi-id"): FakeSnapshot(
+            "multi-id",
+            {
+                "multi": True,
+                "hasMoreRoom": True,
+                "data": {
+                    "target": {
+                        "mode": "bottle",
+                        "start": 200.0,
+                        "lastUpdated": 200.0,
+                        "bottleType": "Formula",
+                        "amount": 90.0,
+                        "units": "ml",
+                        "offset": 240.0,
+                    },
+                    "other": {
+                        "mode": "bottle",
+                        "start": 100.0,
+                        "lastUpdated": 100.0,
+                        "bottleType": "Breast Milk",
+                        "amount": 60.0,
+                        "units": "ml",
+                        "offset": 240.0,
+                    },
+                },
+            },
+            target_revision,
+        )
+    }
+    client = FakeClient(documents)
+    api = make_api(monkeypatch, client)
+    reference = FirebaseHistoryRecordReference(
+        document_id="multi-id",
+        entry_key="target",
+        revision=revision(target_revision),
+    )
+
+    await api.update_bottle_interval(
+        "child",
+        reference,
+        start_time=datetime(2026, 8, 18, 8, 30, tzinfo=timezone.utc),
+        amount=120.0,
+        bottle_type="Breast Milk",
+        units="ml",
+    )
+
+    assert client.last_transaction is not None
+    operations = client.last_transaction.operations
+    container_write = next(
+        data for operation, path, data in operations if operation == "set" and path[-1] == "multi-id"
+    )
+    assert container_write is not None
+    container_entries = cast(dict[str, dict[str, object]], container_write["data"])
+    assert container_entries["target"]["amount"] == 120.0
+    assert container_entries["other"]["amount"] == 60.0
+
+    root_update = next(
+        data for operation, path, data in operations if operation == "update" and path == ("feed", "child")
+    )
+    assert root_update is not None
+    assert cast(dict[str, object], root_update["prefs.lastBottle"])["bottleAmount"] == 120.0
+
+
+async def test_delete_only_bottle_clears_last_bottle_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    target_revision = datetime(2026, 8, 18, 12, 0, tzinfo=timezone.utc)
+    client = FakeClient(
+        {
+            ("feed", "child", "intervals", "bottle-id"): FakeSnapshot(
+                "bottle-id",
+                {
+                    "mode": "bottle",
+                    "start": 200.0,
+                    "lastUpdated": 200.0,
+                    "bottleType": "Formula",
+                    "amount": 90.0,
+                    "units": "ml",
+                    "offset": 240.0,
+                },
+                target_revision,
+            )
+        }
+    )
+    api = make_api(monkeypatch, client)
+    reference = FirebaseHistoryRecordReference(
+        document_id="bottle-id",
+        revision=revision(target_revision),
+    )
+
+    await api.delete_feed_interval("child", reference)
+
+    assert client.last_transaction is not None
+    root_update = next(
+        data
+        for operation, path, data in client.last_transaction.operations
+        if operation == "update" and path == ("feed", "child")
+    )
+    assert root_update is not None
+    assert root_update["prefs.lastBottle"] is firestore.DELETE_FIELD
+
+
+async def test_update_diaper_replaces_optional_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    target_revision = datetime(2026, 8, 18, 12, 0, tzinfo=timezone.utc)
+    client = FakeClient(
+        {
+            ("diaper", "child", "intervals", "diaper-id"): FakeSnapshot(
+                "diaper-id",
+                {
+                    "mode": "both",
+                    "start": 200.0,
+                    "lastUpdated": 200.0,
+                    "offset": 240.0,
+                    "color": "yellow",
+                    "consistency": "solid",
+                    "diaperRash": True,
+                    "notes": "old note",
+                },
+                target_revision,
+            )
+        }
+    )
+    api = make_api(monkeypatch, client)
+    reference = FirebaseHistoryRecordReference(
+        document_id="diaper-id",
+        revision=revision(target_revision),
+    )
+
+    await api.update_diaper_interval(
+        "child",
+        reference,
+        start_time=datetime(2026, 8, 18, 9, 0, tzinfo=timezone.utc),
+        mode="pee",
+        pee_amount="big",
+    )
+
+    assert client.last_transaction is not None
+    interval_write = next(
+        data
+        for operation, path, data in client.last_transaction.operations
+        if operation == "set" and path[-1] == "diaper-id"
+    )
+    assert interval_write is not None
+    assert interval_write["mode"] == "pee"
+    assert interval_write["quantity"] == {"pee": 100.0}
+    assert "color" not in interval_write
+    assert "consistency" not in interval_write
+    assert "diaperRash" not in interval_write
+    assert "notes" not in interval_write
+
+
+async def test_update_growth_replaces_measurements_and_units(monkeypatch: pytest.MonkeyPatch) -> None:
+    target_revision = datetime(2026, 8, 18, 12, 0, tzinfo=timezone.utc)
+    client = FakeClient(
+        {
+            ("health", "child", "data", "growth-id"): FakeSnapshot(
+                "growth-id",
+                {
+                    "_id": "growth-id",
+                    "type": "health",
+                    "mode": "growth",
+                    "start": 200.0,
+                    "lastUpdated": 200.0,
+                    "offset": 240.0,
+                    "weight": 5.0,
+                    "weightUnits": "kg",
+                    "height": 50.0,
+                    "heightUnits": "cm",
+                },
+                target_revision,
+            )
+        }
+    )
+    api = make_api(monkeypatch, client)
+    reference = FirebaseHistoryRecordReference(
+        document_id="growth-id",
+        revision=revision(target_revision),
+    )
+
+    await api.update_growth_entry(
+        "child",
+        reference,
+        start_time=datetime(2026, 8, 18, 9, 0, tzinfo=timezone.utc),
+        weight=12.0,
+        head=15.0,
+        units="imperial",
+    )
+
+    assert client.last_transaction is not None
+    interval_write = next(
+        data
+        for operation, path, data in client.last_transaction.operations
+        if operation == "set" and path[-1] == "growth-id"
+    )
+    assert interval_write is not None
+    assert interval_write["weight"] == 12.0
+    assert interval_write["weightUnits"] == "lbs.oz"
+    assert interval_write["head"] == 15.0
+    assert interval_write["headUnits"] == "hin"
+    assert "height" not in interval_write
+    assert "heightUnits" not in interval_write
+
+
+async def test_edit_validation_happens_before_firestore(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeClient({})
+    api = make_api(monkeypatch, client)
+    reference = FirebaseHistoryRecordReference(document_id="sleep-id", revision="revision")
+
+    with pytest.raises(ValueError, match="timezone"):
+        await api.update_sleep_interval(
+            "child",
+            reference,
+            start_time=datetime(2026, 8, 18, 8, 0),
+            end_time=datetime(2026, 8, 18, 9, 0),
+        )
+
+    assert client.last_transaction is None

--- a/tests/test_history_mutations.py
+++ b/tests/test_history_mutations.py
@@ -38,7 +38,16 @@ class FakeDocumentReference:
 
     async def get(self, transaction=None) -> FakeSnapshot:
         del transaction
-        return self.client.documents[self.path]
+        snapshot = self.client.documents.get(self.path)
+        if snapshot is not None:
+            return snapshot
+        if len(self.path) == 2:
+            return FakeSnapshot(
+                self.path[-1],
+                {},
+                datetime(2026, 8, 18, 10, 0, tzinfo=timezone.utc),
+            )
+        raise KeyError(self.path)
 
 
 class FakeQuery:
@@ -118,15 +127,24 @@ class FakeCollectionReference(FakeQuery):
 class FakeTransaction:
     def __init__(self):
         self.operations: list[tuple[str, tuple[str, ...], dict[str, object] | None]] = []
+        self.options: list[tuple[tuple[str, ...], object]] = []
+        self.committed = False
 
     def set(self, reference: FakeDocumentReference, data: dict[str, object]) -> None:
         self.operations.append(("set", reference.path, deepcopy(data)))
 
-    def update(self, reference: FakeDocumentReference, data: dict[str, object]) -> None:
+    def update(self, reference: FakeDocumentReference, data: dict[str, object], option=None) -> None:
         self.operations.append(("update", reference.path, deepcopy(data)))
+        if option is not None:
+            self.options.append((reference.path, option))
 
-    def delete(self, reference: FakeDocumentReference) -> None:
+    def delete(self, reference: FakeDocumentReference, option=None) -> None:
         self.operations.append(("delete", reference.path, None))
+        if option is not None:
+            self.options.append((reference.path, option))
+
+    async def commit(self) -> None:
+        self.committed = True
 
 
 class FakeClient:
@@ -140,6 +158,14 @@ class FakeClient:
     def transaction(self) -> FakeTransaction:
         self.last_transaction = FakeTransaction()
         return self.last_transaction
+
+    def batch(self) -> FakeTransaction:
+        self.last_transaction = FakeTransaction()
+        return self.last_transaction
+
+    @staticmethod
+    def write_option(**kwargs):
+        return kwargs
 
 
 def make_api(monkeypatch: pytest.MonkeyPatch, client: FakeClient) -> HuckleberryAPI:
@@ -216,11 +242,10 @@ async def test_stale_reference_is_rejected_before_writes(monkeypatch: pytest.Mon
     with pytest.raises(HuckleberryRecordConflictError):
         await api.delete_sleep_interval("child", stale_reference)
 
-    assert client.last_transaction is not None
-    assert client.last_transaction.operations == []
+    assert client.last_transaction is None
 
 
-async def test_delete_repairs_last_sleep_in_same_transaction(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_delete_repairs_last_sleep_in_revision_guarded_batch(monkeypatch: pytest.MonkeyPatch) -> None:
     target_revision = datetime(2026, 8, 18, 12, 0, tzinfo=timezone.utc)
     documents = {
         ("sleep", "child", "intervals", "latest-id"): FakeSnapshot(
@@ -251,6 +276,11 @@ async def test_delete_repairs_last_sleep_in_same_transaction(monkeypatch: pytest
     )
     assert root_update is not None
     assert root_update["prefs.lastSleep"] == {"start": 100.0, "duration": 30.0, "offset": 240.0}
+    assert client.last_transaction.committed is True
+    assert {path for path, _option in client.last_transaction.options} == {
+        ("sleep", "child", "intervals", "latest-id"),
+        ("sleep", "child"),
+    }
 
 
 async def test_update_multi_bottle_preserves_container_and_repairs_cache(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -305,7 +335,7 @@ async def test_update_multi_bottle_preserves_container_and_repairs_cache(monkeyp
     assert client.last_transaction is not None
     operations = client.last_transaction.operations
     container_write = next(
-        data for operation, path, data in operations if operation == "set" and path[-1] == "multi-id"
+        data for operation, path, data in operations if operation == "update" and path[-1] == "multi-id"
     )
     assert container_write is not None
     container_entries = cast(dict[str, dict[str, object]], container_write["data"])
@@ -394,15 +424,15 @@ async def test_update_diaper_replaces_optional_fields(monkeypatch: pytest.Monkey
     interval_write = next(
         data
         for operation, path, data in client.last_transaction.operations
-        if operation == "set" and path[-1] == "diaper-id"
+        if operation == "update" and path[-1] == "diaper-id"
     )
     assert interval_write is not None
     assert interval_write["mode"] == "pee"
     assert interval_write["quantity"] == {"pee": 100.0}
-    assert "color" not in interval_write
-    assert "consistency" not in interval_write
-    assert "diaperRash" not in interval_write
-    assert "notes" not in interval_write
+    assert interval_write["color"] is firestore.DELETE_FIELD
+    assert interval_write["consistency"] is firestore.DELETE_FIELD
+    assert interval_write["diaperRash"] is firestore.DELETE_FIELD
+    assert interval_write["notes"] is firestore.DELETE_FIELD
 
 
 async def test_update_growth_replaces_measurements_and_units(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -446,15 +476,15 @@ async def test_update_growth_replaces_measurements_and_units(monkeypatch: pytest
     interval_write = next(
         data
         for operation, path, data in client.last_transaction.operations
-        if operation == "set" and path[-1] == "growth-id"
+        if operation == "update" and path[-1] == "growth-id"
     )
     assert interval_write is not None
     assert interval_write["weight"] == 12.0
     assert interval_write["weightUnits"] == "lbs.oz"
     assert interval_write["head"] == 15.0
     assert interval_write["headUnits"] == "hin"
-    assert "height" not in interval_write
-    assert "heightUnits" not in interval_write
+    assert interval_write["height"] is firestore.DELETE_FIELD
+    assert interval_write["heightUnits"] is firestore.DELETE_FIELD
 
 
 async def test_edit_validation_happens_before_firestore(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What changed

- add stable Firestore document and multi-entry references to sleep, feed, diaper, and health history reads
- add exact-record getters with optimistic revision checks
- add typed update and delete methods for sleep, nursing, bottle, diaper, and growth records
- support legacy batched `multi` documents as well as regular interval documents
- update the affected `prefs.last*` cache in the same Firestore transaction
- add public conflict, not-found, and malformed-reference exceptions

## Why

The existing list methods return payloads without the Firestore document identity. Callers therefore cannot safely target an exact historical record for editing or deletion. Matching by timestamp is ambiguous, and changing an interval without repairing the root `prefs.last*` value can leave Huckleberry summaries stale.

## Behavior

History record references contain the document ID, optional multi-entry key, and Firestore update revision. Mutations fail closed when the record changed after it was listed. A transaction applies the exact mutation and recomputes the affected latest-record cache atomically.

Existing `list_*` methods remain backward compatible. New `list_*_records` methods expose mutation references.

## Validation

- `uv run towncrier check --compare-with origin/main`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check --python-version 3.14 --ignore unknown-argument`
- `uv run pytest -q`: 36 passed, 74 credential-gated integration tests skipped
